### PR TITLE
Accel redirect

### DIFF
--- a/doc/storage.markdown
+++ b/doc/storage.markdown
@@ -128,6 +128,28 @@ __NOTE:__ When both the metastore and entitystore are configured to use file
 system storage, they should be set to different paths to prevent any chance of
 collision.
 
+### AccelRedirect Storage
+
+Stores cached entries just like Disk storage, but uses nginx's
+[X-Accel-Redirect](http://wiki.nginx.org/NginxXSendfile) to serve the cached
+files.  This can only be used as an entity store.  The redirect root is 
+configured by adding an entity to the uri.  
+
+Example:
+
+ * Rack::Cache configuration:
+
+    use Rack::Cache,
+      :metastore   => 'file:/var/cache/rack/meta',
+      :entitystore => 'entitystore:/var/cache/rack/body#cache'
+
+ * Nginx configuration:
+ 
+    location /cache/ {
+      internal;
+      alias /var/cache/rack/body/;
+    }
+
 ### Memcached Storage
 
 Stores cached entries in a remote [memcached](http://www.danga.com/memcached/)

--- a/lib/rack/cache/metastore.rb
+++ b/lib/rack/cache/metastore.rb
@@ -37,8 +37,8 @@ module Rack::Cache
       return nil if match.nil?
 
       req, res = match
-      if body = entity_store.open(res['X-Content-Digest'])
-        restore_response(res, body)
+      if response = entity_store.restore_response(res)
+        response
       else
         # TODO the metastore referenced an entity that doesn't exist in
         # the entitystore. we definitely want to return nil but we should
@@ -56,10 +56,7 @@ module Rack::Cache
       # write the response body to the entity store if this is the
       # original response.
       if response.headers['X-Content-Digest'].nil?
-        digest, size = entity_store.write(response.body)
-        response.headers['X-Content-Digest'] = digest
-        response.headers['Content-Length'] = size.to_s unless response.headers['Transfer-Encoding']
-        response.body = entity_store.open(digest)
+        entity_store.write_response(response)
       end
 
       # read existing cache entries, remove non-varying, and add this one to


### PR DESCRIPTION
I really like Rack::Cache, thanks for releasing it.

I have a tiny side project that I'm working on, and I wanted to try and squeeze as much performance/capacity out of my small VPS as possible.  Using Nginx's x-accel-redirect feature seems like it'd allow me to keep memcached's memory footprint down and also allow me to bypass ruby for the entity IO.

Let me know what you think.

Cheers,
-Adam
