### PR TITLE
Add rack-cache.rb for compatibility

### DIFF
--- a/lib/rack-cache.rb
+++ b/lib/rack-cache.rb
@@ -1,0 +1,1 @@
+require 'rack/cache'


### PR DESCRIPTION
Simple addition so that you don't need :require => 'rack/cache' in your Gemfile
