### PR TITLE
Added file to lib to make bundler auto-require rack/cache

### DIFF
--- a/lib/rack-cache.rb
+++ b/lib/rack-cache.rb
@@ -1,0 +1,1 @@
+require 'rack/cache'


### PR DESCRIPTION
Hi!

I've seen that when using the gem in a bundler environment you need to explicitly declare

require 'rack/cache'

this is counter-intuitive and doesn't follow the standards of at least Rails 3 and bundler so I've added a file that will require 'rack/cache'.

Is this ok?

Congrats for this awesome gem
