### PR TITLE
Set custom stores

### DIFF
--- a/doc/storage.markdown
+++ b/doc/storage.markdown
@@ -73,18 +73,32 @@ Storage Registration
 --------------------
 
 If the needs for configuration your stores are more complex than the URIs allow,
-you may register a manually instantiated store.  You can do this directly on the
-`Rack::Cache::Storage.instance` singleton, and pass the name as the `:metastore`
-and `entitystore` values in the rack configuration:
+you may register a manually instantiated store.  You can do this by calling the
+`register_metastore` and `register_entitystore` methods on the __Rack::Cache__ 
+instance when you set it up in your rack configuration.
 
-    Rack::Cache::Storage.instance.register_metastore :my_store,
+    use Rack::Cache do |rack_cache|
+      rack_cache.register_metastore, :my_metas,
+        ::Cache::MetaStore::Heap.new
+      rack_cache.register_entitystore, :my_entities,
+        ::Cache::EntityStore::Heap.new
+      rack_cache.use :metastore, :my_metas
+      rack_cache.use :entitystore, :my_entities
+    end
+
+You can also register storage instances directly on the`Rack::Cache::Storage.instance` 
+singleton, and pass the name as the `:metastore` and `entitystore` values in the rack 
+configuration: 
+
+    Rack::Cache::Storage.instance.register_metastore :my_metas,
       Rack::Cache::MetaStore::Heap.new
-    Rack::Cache::Storage.instance.register_entitystore :my_store,
+    Rack::Cache::Storage.instance.register_entitystore :my_entities,
       Rack::Cache::EntityStore::Heap.new
 
     use Rack::Cache,
-      :metastore => :my_store,
-      :entitystore => :my_store
+      :metastore => :my_metas,
+      :entitystore => :my_entities
+
 
 Storage Implementations
 -----------------------

--- a/doc/storage.markdown
+++ b/doc/storage.markdown
@@ -52,8 +52,8 @@ Storage Configuration
 
 The MetaStore and EntityStore used for a particular request is determined by
 inspecting the `rack-cache.metastore` and `rack-cache.entitystore` Rack env
-variables. The value of these variables is a URI that identifies the storage
-type and location (URI formats are documented in the following section).
+variables. The value of these variables is a URI or name that identifies the 
+storage type and location (URI formats are documented in a following section).
 
 The `heap:/` storage is assumed if either storage type is not explicitly
 provided. This storage type has significant drawbacks for most types of
@@ -68,6 +68,23 @@ __Rack::Cache__ object is added to the Rack middleware pipeline as follows:
 
 Alternatively, the `rack-cache.metastore` and `rack-cache.entitystore`
 variables may be set in the Rack environment by an upstream component.
+
+Storage Registration
+--------------------
+
+If the needs for configuration your stores are more complex than the URIs allow,
+you may register a manually instantiated store.  You can do this directly on the
+`Rack::Cache::Storage.instance` singleton, and pass the name as the `:metastore`
+and `entitystore` values in the rack configuration:
+
+    Rack::Cache::Storage.instance.register_metastore :my_store,
+      Rack::Cache::MetaStore::Heap.new
+    Rack::Cache::Storage.instance.register_entitystore :my_store,
+      Rack::Cache::EntityStore::Heap.new
+
+    use Rack::Cache,
+      :metastore => :my_store,
+      :entitystore => :my_store
 
 Storage Implementations
 -----------------------

--- a/lib/rack/cache/context.rb
+++ b/lib/rack/cache/context.rb
@@ -29,15 +29,15 @@ module Rack::Cache
     # The configured MetaStore instance. Changing the rack-cache.metastore
     # value effects the result of this method immediately.
     def metastore
-      uri = options['rack-cache.metastore']
-      storage.resolve_metastore_uri(uri)
+      uri_or_name = options['rack-cache.metastore']
+      storage.resolve_metastore(uri_or_name)
     end
 
     # The configured EntityStore instance. Changing the rack-cache.entitystore
     # value effects the result of this method immediately.
     def entitystore
-      uri = options['rack-cache.entitystore']
-      storage.resolve_entitystore_uri(uri)
+      uri_or_name = options['rack-cache.entitystore']
+      storage.resolve_entitystore(uri_or_name)
     end
 
     # The Rack call interface. The receiver acts as a prototype and runs

--- a/lib/rack/cache/context.rb
+++ b/lib/rack/cache/context.rb
@@ -26,11 +26,21 @@ module Rack::Cache
         private_headers.map { |name| "HTTP_#{name.upcase.tr('-', '_')}" }
     end
 
+    # Register a MetaStore instance.  See Rack::Cache::Storage#register_metastore
+    def register_metastore(*args)
+      Storage.instance.register_metastore(*args)
+    end
+
     # The configured MetaStore instance. Changing the rack-cache.metastore
     # value effects the result of this method immediately.
     def metastore
       uri_or_name = options['rack-cache.metastore']
       storage.resolve_metastore(uri_or_name)
+    end
+
+    # Register an EntityStore instance.  See Rack::Cache::Storage#register_entitystore
+    def register_entitystore(*args)
+      Storage.instance.register_entitystore(*args)
     end
 
     # The configured EntityStore instance. Changing the rack-cache.entitystore

--- a/test/storage_test.rb
+++ b/test/storage_test.rb
@@ -7,40 +7,50 @@ describe 'Rack::Cache::Storage' do
   end
 
   it "fails when an unknown URI scheme is provided" do
-    lambda { @storage.resolve_metastore_uri('foo:/') }.should.raise
+    lambda { @storage.resolve_metastore('foo:/') }.should.raise
   end
   it "creates a new MetaStore for URI if none exists" do
-    @storage.resolve_metastore_uri('heap:/').
+    @storage.resolve_metastore('heap:/').
       should.be.kind_of Rack::Cache::MetaStore
   end
   it "returns an existing MetaStore instance for URI that exists" do
-    store = @storage.resolve_metastore_uri('heap:/')
-    @storage.resolve_metastore_uri('heap:/').should.be.same_as store
+    store = @storage.resolve_metastore('heap:/')
+    @storage.resolve_metastore('heap:/').should.be.same_as store
   end
   it "creates a new EntityStore for URI if none exists" do
-    @storage.resolve_entitystore_uri('heap:/').
+    @storage.resolve_entitystore('heap:/').
       should.be.kind_of Rack::Cache::EntityStore
   end
   it "returns an existing EntityStore instance for URI that exists" do
-    store = @storage.resolve_entitystore_uri('heap:/')
-    @storage.resolve_entitystore_uri('heap:/').should.be.same_as store
+    store = @storage.resolve_entitystore('heap:/')
+    @storage.resolve_entitystore('heap:/').should.be.same_as store
   end
   it "clears all URI -> store mappings with #clear" do
-    meta = @storage.resolve_metastore_uri('heap:/')
-    entity = @storage.resolve_entitystore_uri('heap:/')
+    meta = @storage.resolve_metastore('heap:/')
+    entity = @storage.resolve_entitystore('heap:/')
     @storage.clear
-    @storage.resolve_metastore_uri('heap:/').should.not.be.same_as meta
-    @storage.resolve_entitystore_uri('heap:/').should.not.be.same_as entity
+    @storage.resolve_metastore('heap:/').should.not.be.same_as meta
+    @storage.resolve_entitystore('heap:/').should.not.be.same_as entity
+  end
+  it "registers a MetaStore by name" do
+    store = Rack::Cache::MetaStore::Heap.new
+    @storage.register_metastore(:foo, store)
+    @storage.resolve_metastore(:foo).should.be.same_as store
+  end
+  it "registers an EntityStore by name" do
+    store = Rack::Cache::EntityStore::Heap.new
+    @storage.register_entitystore(:foo, store)
+    @storage.resolve_entitystore(:foo).should.be.same_as store
   end
 
   describe 'Heap Store URIs' do
     %w[heap:/ mem:/].each do |uri|
       it "resolves #{uri} meta store URIs" do
-        @storage.resolve_metastore_uri(uri).
+        @storage.resolve_metastore(uri).
           should.be.kind_of Rack::Cache::MetaStore
       end
       it "resolves #{uri} entity store URIs" do
-        @storage.resolve_entitystore_uri(uri).
+        @storage.resolve_entitystore(uri).
           should.be.kind_of Rack::Cache::EntityStore
       end
     end
@@ -57,11 +67,11 @@ describe 'Rack::Cache::Storage' do
 
     %w[file: disk:].each do |uri|
       it "resolves #{uri} meta store URIs" do
-        @storage.resolve_metastore_uri(uri + @temp_dir).
+        @storage.resolve_metastore(uri + @temp_dir).
           should.be.kind_of Rack::Cache::MetaStore
       end
       it "resolves #{uri} entity store URIs" do
-        @storage.resolve_entitystore_uri(uri + @temp_dir).
+        @storage.resolve_entitystore(uri + @temp_dir).
           should.be.kind_of Rack::Cache::EntityStore
       end
     end
@@ -73,18 +83,18 @@ describe 'Rack::Cache::Storage' do
       %w[memcache: memcached:].each do |scheme|
         it "resolves #{scheme} meta store URIs" do
           uri = scheme + '//' + ENV['MEMCACHED']
-          @storage.resolve_metastore_uri(uri).
+          @storage.resolve_metastore(uri).
             should.be.kind_of Rack::Cache::MetaStore
         end
         it "resolves #{scheme} entity store URIs" do
           uri = scheme + '//' + ENV['MEMCACHED']
-          @storage.resolve_entitystore_uri(uri).
+          @storage.resolve_entitystore(uri).
             should.be.kind_of Rack::Cache::EntityStore
         end
       end
       it 'supports namespaces in memcached: URIs' do
         uri = "memcached://" + ENV['MEMCACHED'] + "/namespace"
-        @storage.resolve_metastore_uri(uri).
+        @storage.resolve_metastore(uri).
            should.be.kind_of Rack::Cache::MetaStore
       end
     end


### PR DESCRIPTION
This allows the registration and resolution of custom stores.

Example from updated docs:

```ruby
use Rack::Cache do |rack_cache|
  rack_cache.register_metastore, :my_metas,
    ::Cache::MetaStore::Heap.new
  rack_cache.register_entitystore, :my_entities,
    ::Cache::EntityStore::Heap.new
  rack_cache.use :metastore, :my_metas
  rack_cache.use :entitystore, :my_entities
end
```

or

```ruby
Rack::Cache::Storage.instance.register_metastore :my_metas,
  Rack::Cache::MetaStore::Heap.new
Rack::Cache::Storage.instance.register_entitystore :my_entities,
  Rack::Cache::EntityStore::Heap.new

use Rack::Cache,
  :metastore => :my_metas,
  :entitystore => :my_entities
```

This is especially useful for redis-store when you use a distributed instance:

```ruby
redis_servers = %w(redis://app1.domain.com redis://app2.domain.com)
use Rack::Cache do |rack_cache|
  rack_cache.register_metastore, :default,
    Rack::Cache::MetaStore::Redis.new(redis_servers)
  rack_cache.use :metastore, :my_metas

end
```