### PR TITLE
Warnings removed.

### DIFF
--- a/lib/rack/cache/context.rb
+++ b/lib/rack/cache/context.rb
@@ -18,6 +18,7 @@ module Rack::Cache
     def initialize(backend, options={})
       @backend = backend
       @trace = []
+      @env = nil
 
       initialize_options options
       yield self if block_given?

--- a/lib/rack/cache/metastore.rb
+++ b/lib/rack/cache/metastore.rb
@@ -37,7 +37,7 @@ module Rack::Cache
       match = entries.detect{|req,res| requests_match?(res['Vary'], env, req)}
       return nil if match.nil?
 
-      req, res = match
+      _, res = match
       if body = entity_store.open(res['X-Content-Digest'])
         restore_response(res, body)
       else


### PR DESCRIPTION
I removed this because this gem is used in rails 
and when we run rails test then the warnings are coming.
All test passing after these changes.
