### PR TITLE
added allow_reload_check option to "secure" cache refresh

### DIFF
--- a/lib/rack/cache/context.rb
+++ b/lib/rack/cache/context.rb
@@ -158,7 +158,7 @@ module Rack::Cache
     # stale, attempt to #validate the entry with the backend using conditional
     # GET. When no matching cache entry is found, trigger #miss processing.
     def lookup
-      if @request.no_cache? && allow_reload?
+      if @request.no_cache? && allow_reload? && allow_reload_check.call(@request)
         record :reload
         fetch
       else

--- a/lib/rack/cache/options.rb
+++ b/lib/rack/cache/options.rb
@@ -92,6 +92,16 @@ module Rack::Cache
     # default for compliance with RFC 2616.
     option_accessor :allow_reload
 
+    # If you want to restrict the ability of a cache refresh you are able
+    # to supply a lambda to this option. It will recieve the current 
+    # Rack::[Cache::]Request as an argument. Unless it returns false the reload
+    # will be allowed.
+    #
+    # Example: check for existance of an "admin" cookie
+    # :allow_reload_check => lambda { |request| !request.cookies['admin'].blank? }
+    option_accessor :allow_reload_check
+
+
     # Specifies whether the client can force a cache revalidate by including
     # a Cache-Control "max-age=0" directive in the request. This is enabled by
     # default for compliance with RFC 2616.
@@ -140,6 +150,7 @@ module Rack::Cache
         'rack-cache.default_ttl'      => 0,
         'rack-cache.private_headers'  => ['Authorization', 'Cookie'],
         'rack-cache.allow_reload'     => false,
+        'rack-cache.allow_reload_check' => lambda { |request| true },
         'rack-cache.allow_revalidate' => false,
         'rack-cache.use_native_ttl'   => false,
       }


### PR DESCRIPTION
If you want to restrict the ability of a cache refresh you are able
to supply a lambda to this option. It will recieve the current
Rack::[Cache::]Request as an argument. Unless it returns false the reload
will be allowed.

Example: check for existance of an "admin" cookie
:allow_reload_check => lambda { |request| !request.cookies['admin'].blank? }
