### PR TITLE
add support for r-maxage

### DIFF
--- a/lib/rack/cache/cachecontrol.rb
+++ b/lib/rack/cache/cachecontrol.rb
@@ -125,6 +125,20 @@ module Rack
       end
       alias_method :s_maxage, :shared_max_age
 
+      # If a response includes a r-maxage directive, then for a reverse cache
+      # (but not for a private or proxy cache), the maximum age specified by
+      # this directive overrides the maximum age specified by either the max-age
+      # directive, the s-maxage directive, or the Expires header. The r-maxage
+      # directive also implies the semantics of the proxy-revalidate directive.
+      # i.e., that the reverse cache must not use the entry after it becomes
+      # stale to respond to a subsequent request without first revalidating it
+      # with the origin server. The r-maxage directive is always ignored by
+      # private and proxy caches.
+      def reverse_max_age
+        self['r-maxage'].to_i  if key?('r-maxage')
+      end
+      alias_method :r_maxage, :reverse_max_age
+
       # Because a cache MAY be configured to ignore a server's specified
       # expiration time, and because a client request MAY include a max-
       # stale directive (which has a similar effect), the protocol also

--- a/lib/rack/cache/response.rb
+++ b/lib/rack/cache/response.rb
@@ -151,13 +151,14 @@ module Rack::Cache
 
     # The number of seconds after the time specified in the response's Date
     # header when the the response should no longer be considered fresh. First
-    # check for a s-maxage directive, then a max-age directive, and then fall
-    # back on an expires header; return nil when no maximum age can be
-    # established.
+    # check for a r-maxage directive, then a s-maxage directive, then a max-age
+    # directive, and then fall back on an expires header; return nil when no
+    # maximum age can be established.
     def max_age
-      cache_control.shared_max_age ||
-        cache_control.max_age ||
-        (expires && (expires - date))
+      cache_control.reverse_max_age ||
+        cache_control.shared_max_age ||
+          cache_control.max_age ||
+           (expires && (expires - date))
     end
 
     # The value of the Expires header as a Time object.
@@ -175,6 +176,12 @@ module Rack::Cache
     # to shared caches.
     def shared_max_age=(value)
       self.cache_control = cache_control.merge('s-maxage' => value.to_s)
+    end
+
+    # Like #shared_max_age= but sets the r-maxage directive, which applies only
+    # to reverse caches.
+    def reverse_max_age=(value)
+      self.cache_control = cache_control.merge('r-maxage' => value.to_s)
     end
 
     # The response's time-to-live in seconds, or nil when no freshness

--- a/test/cachecontrol_test.rb
+++ b/test/cachecontrol_test.rb
@@ -93,6 +93,16 @@ describe 'Rack::Cache::CacheControl' do
     cache_control.shared_max_age.should.be.nil
   end
 
+  it 'responds to #reverse_max_age with an integer when r-maxage directive present' do
+    cache_control = Rack::Cache::CacheControl.new('public, r-maxage=600')
+    cache_control.reverse_max_age.should.equal 600
+  end
+
+  it 'responds to #reverse_max_age with nil when no r-maxage directive present' do
+    cache_control = Rack::Cache::CacheControl.new('public')
+    cache_control.reverse_max_age.should.be.nil
+  end
+
   it 'responds to #public? truthfully when public directive present' do
     cache_control = Rack::Cache::CacheControl.new('public')
     cache_control.should.be.public


### PR DESCRIPTION
r-maxage is a new directive that takes precendence over s-maxage and
max-age.

While s-maxage is honored by any shared cache, r-maxage is only taken
into account by reverse proxy caches, and thus ignored by proxy and
private caches. Setting r-maxage allows applications to ensure the
response is only cached by their reverse cache, and thus are able in
particular to purge the cache knowing that it will not remain stale in
intermediate proxy servers.
