### PR TITLE
Removing Gemfile.lock from gemspec manifest

### DIFF
--- a/rack-cache.gemspec
+++ b/rack-cache.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
     CHANGES
     COPYING
     Gemfile
-    Gemfile.lock
     README
     Rakefile
     TODO


### PR DESCRIPTION
The Gemfile.lock file seems to have been left in the gemspec from #53.
