### PR TITLE
Gracefully degrade when cache store goes offline

### DIFF
--- a/lib/rack/cache/metastore.rb
+++ b/lib/rack/cache/metastore.rb
@@ -64,7 +64,7 @@ module Rack::Cache
         end
         response.headers['X-Content-Digest'] = digest
         response.headers['Content-Length'] = size.to_s unless response.headers['Transfer-Encoding']
-        response.body = entity_store.open(digest)
+        response.body = entity_store.open(digest) || response.body
       end
 
       # read existing cache entries, remove non-varying, and add this one to


### PR DESCRIPTION
This fixes issue #42.

When storing a response in `MetaStore#store`, the cached response body is read
back and subsequently used as response body. If the cache store is offline then
the read-back value may be nil. In that case, the store operation overwrites a
valid response body with nil.

We noticed this problem when we temporarily took down memcached during
maintenance. We expected the site to slow down, but cached pages instead became
empty.

---

The idea of the implementation is to only overwrite the response body if we get
a hit when reading back the body from the cache. The aim is to change as little
code as possible. I do not understand the code base, so there are probably many
assumptions that I am not aware of.

The test creates new stores that implement all(?) abstract methods with
versions that mimic an offline store and then tries to store a value. I'm
unsure whether the preferred style is to define the classes inside or outside
the examples.

Other tests explicitly check that the response body is not the same after
calling `#store`. I'm assuming that this is because we want to use IO-streams or
something from the backing store, and that it does not apply in this case. I am
unsure though, and would like some feedback on that.

Feedback is more than welcome
