### PR TITLE
Issue 70 - Make Rack::Cache multithread friendly

### DIFF
--- a/lib/rack/cache/context.rb
+++ b/lib/rack/cache/context.rb
@@ -45,7 +45,7 @@ module Rack::Cache
     # each request in a dup object unless the +rack.run_once+ variable is
     # set in the environment.
     def call(env)
-      if env['rack.run_once']
+      if env['rack.run_once'] && !env['rack.multithread']
         call! env
       else
         clone.call! env

--- a/test/spec_setup.rb
+++ b/test/spec_setup.rb
@@ -149,6 +149,7 @@ module CacheContextHelpers
   def request(method, uri='/', opts={})
     opts = {
       'rack.run_once' => true,
+      'rack.multithread' => false,
       'rack.errors' => @errors,
       'rack-cache.storage' => @storage
     }.merge(opts)


### PR DESCRIPTION
As described in https://github.com/rtomayko/rack-cache/issues/70, this will fix the issue with asstes not being loaded correctly when using puma, a multithreaded ruby app server. This changes /lib/rack/cache/context.rb call method from 

```
def call(env)
  if env['rack.run_once']
    call! env
  else
    clone.call! env
  end
end
```

to

```
def call(env)
  if env['rack.run_once'] && !env['rack.multithread']
    call! env
  else
    clone.call! env
  end
end
```

Let me know what you think.
