### PR TITLE
Rescue StandardError instead of Exception so things like interrupts continue to work.

### DIFF
--- a/lib/rack/cache/context.rb
+++ b/lib/rack/cache/context.rb
@@ -147,7 +147,7 @@ module Rack::Cache
     # See RFC2616 13.10
     def invalidate
       metastore.invalidate(@request, entitystore)
-    rescue Exception => e
+    rescue => e
       log_error(e)
       pass
     else
@@ -167,7 +167,7 @@ module Rack::Cache
       else
         begin
           entry = metastore.lookup(@request, entitystore)
-        rescue Exception => e
+        rescue => e
           log_error(e)
           return pass
         end
@@ -266,7 +266,7 @@ module Rack::Cache
       strip_ignore_headers(response)
       metastore.store(@request, response, entitystore)
       response.headers['Age'] = response.age.to_s
-    rescue Exception => e
+    rescue => e
       log_error(e)
       nil
     else


### PR DESCRIPTION
I lack the historical context for the original rescue clauses (dating back to 2009) and don't know if there was a store implementation that would raise an exception that didn't descend from StandardError.  But swallowing all exceptions can lead to some unexpected behavior, especially in a multi-threaded environment.