### PR TITLE
After overriding the REQUEST_METHOD, store the original request method in "rack.methodoverride.original_method"

### DIFF
--- a/lib/rack/cache/context.rb
+++ b/lib/rack/cache/context.rb
@@ -191,7 +191,7 @@ module Rack::Cache
     # as a template for a conditional GET request with the backend.
     def validate(entry)
       # send no head requests because we want content
-      @env['REQUEST_METHOD'] = 'GET'
+      convert_head_to_get!
 
       # add our cached last-modified validator to the environment
       @env['HTTP_IF_MODIFIED_SINCE'] = entry.last_modified
@@ -240,7 +240,7 @@ module Rack::Cache
     # caching of the response when the backend returns a 304.
     def fetch
       # send no head requests because we want content
-      @env['REQUEST_METHOD'] = 'GET'
+      convert_head_to_get!
 
       response = forward
 
@@ -293,6 +293,14 @@ module Rack::Cache
         @env['rack.logger'].send(level, message)
       else
         @env['rack.errors'].write(message)
+      end
+    end
+
+    # send no head requests because we want content
+    def convert_head_to_get!
+      if @env['REQUEST_METHOD'] == 'HEAD'
+        @env['REQUEST_METHOD'] = 'GET'
+        @env['rack.methodoverride.original_method'] = 'HEAD'
       end
     end
   end

--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -742,6 +742,19 @@ describe 'Rack::Cache::Context' do
     count.should.equal 3
   end
 
+  it 'stores HEAD as original_method on HEAD requests' do
+    respond_with do |req,res|
+      res.status = 200
+      res.body = []
+      req.request_method.should.equal 'GET'
+      req.env['rack.methodoverride.original_method'].should.equal 'HEAD'
+    end
+
+    head '/'
+    app.should.be.called
+    response.body.should.equal ''
+  end
+
   it 'passes HEAD requests through directly on pass' do
     respond_with do |req,res|
       res.status = 200


### PR DESCRIPTION
This is the same patch as https://github.com/rtomayko/rack-cache/pull/69 - I'm reopening it, because when you don't set rack.methodoverride.original_method after overriding the request method, there's no way to know what the original request was. 