### PR TITLE
Update Gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.bundle
 \[.
 tags
 .vimrc
@@ -14,4 +15,3 @@ tags
 /doc/storage.html
 /doc/faq.html
 Gemfile.lock
-

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
-source :rubygems
+source 'https://rubygems.org/'
+
 gemspec


### PR DESCRIPTION
Update the `Gemfile` to resolve a deprecation warning, and ignore the `.bundle` directory.