### PR TITLE
Fix stale responses with no Last-Modified.

### DIFF
--- a/lib/rack/cache/context.rb
+++ b/lib/rack/cache/context.rb
@@ -194,7 +194,7 @@ module Rack::Cache
       @env['REQUEST_METHOD'] = 'GET'
 
       # add our cached last-modified validator to the environment
-      @env['HTTP_IF_MODIFIED_SINCE'] = entry.last_modified
+      @env['HTTP_IF_MODIFIED_SINCE'] = entry.last_modified if entry.last_modified
 
       # Add our cached etag validator to the environment.
       # We keep the etags from the client to handle the case when the client


### PR DESCRIPTION
When caching a request with headers like this:

    Cache-Control: max-age=300, public
    ETag: "5c564d692c85b70068fd76ea25f2be2f"

Everything works fine while fresh, but once stale, an error is being raised from within `Net::HTTP`, since there's no `Last-Modified` header.

See #85 for the full background.

I spent around an hour trying to write a failing spec for this, but was unsuccessful. Maybe someone with more knowledge of this gem and its test environment would be more successful.