### PR TITLE
Add railtie and Rails entity and metastores

### DIFF
--- a/lib/rack/cache.rb
+++ b/lib/rack/cache.rb
@@ -1,4 +1,5 @@
 require 'rack'
+require 'rack/cache/railtie' if defined?(Rails)
 
 # = HTTP Caching For Rack
 #

--- a/lib/rack/cache/metastore.rb
+++ b/lib/rack/cache/metastore.rb
@@ -380,6 +380,33 @@ module Rack::Cache
       end
     MEMCACHED = MEMCACHE
 
+    class RailsStore < MetaStore
+      def self.resolve(uri)
+        new
+      end
+
+      def initialize(store = Rails.cache)
+        @store = store
+      end
+
+      def purge(key)
+        @store.delete(key)
+        nil
+      end
+
+      def read(key)
+        if data = @store.read(key)
+          Marshal.load(data)
+        else
+          []
+        end
+      end
+
+      def write(key, value)
+        @store.write(key, Marshal.dump(value))
+      end
+    end
+
     class GAEStore < MetaStore
       attr_reader :cache
 

--- a/lib/rack/cache/railtie.rb
+++ b/lib/rack/cache/railtie.rb
@@ -1,0 +1,43 @@
+module Rack::Cache
+  class Railtie < Rails::Railtie
+    initializer "rack-cache.install_middleware" do |app|
+      params = app.config.action_dispatch.rack_cache
+      next unless params
+
+      # If this require succeeds, then we are running with an older version of
+      # Rails that has its own configuration process for rack-cache, and we
+      # should not interfere with it.
+      begin
+        require "action_dispatch/http/rack_cache"
+        next
+      rescue LoadError; end
+
+      if params == true
+        params = {
+          :metastore => "rails:/",
+          :entitystore => "rails:/",
+          :verbose => false
+        }
+      end
+
+      # We want to position Rack::Cache downstream of a few of these components
+      # of the default Rails middleware stack.
+      if app.config.serve_static_assets
+        upstream = ::ActionDispatch::Static
+      elsif app.config.action_dispatch.x_sendfile_header
+        upstream = ::Rack::Sendfile
+      elsif app.config.force_ssl
+        upstream = ::ActionDispatch::SSL
+      end
+
+      if upstream
+        app.middleware.insert_after(upstream, Rack::Cache, params)
+      else
+        app.middleware.insert(0, Rack::Cache, params)
+      end
+
+      Rack::Cache::MetaStore::RAILS = Rack::Cache::MetaStore::RailsStore
+      Rack::Cache::EntityStore::RAILS = Rack::Cache::EntityStore::RailsStore
+    end
+  end
+end

--- a/rack-cache.gemspec
+++ b/rack-cache.gemspec
@@ -66,6 +66,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bacon'
   s.add_development_dependency 'memcached'
   s.add_development_dependency 'dalli'
+  s.add_development_dependency 'active_support'
 
   s.has_rdoc = true
   s.homepage = "http://rtomayko.github.com/rack-cache/"

--- a/test/entitystore_test.rb
+++ b/test/entitystore_test.rb
@@ -265,4 +265,16 @@ describe 'Rack::Cache::EntityStore' do
       behaves_like 'A Rack::Cache::EntityStore Implementation'
     end
   end
+
+  describe 'RailsStore' do
+    before do
+      @store = Rack::Cache::EntityStore::RailsStore.new(
+          ActiveSupport::Cache::MemoryStore.new)
+    end
+    after do
+      @store = nil
+    end
+
+    behaves_like 'A Rack::Cache::EntityStore Implementation'
+  end
 end

--- a/test/metastore_test.rb
+++ b/test/metastore_test.rb
@@ -355,4 +355,14 @@ describe 'Rack::Cache::MetaStore' do
 
   end
 
+  describe 'RailsStore' do
+    before do
+      @rails_cache = ActiveSupport::Cache::MemoryStore.new
+      @store = Rack::Cache::MetaStore::RailsStore.new(@rails_cache)
+      @entity_store = Rack::Cache::EntityStore::RailsStore.new(@rails_cache)
+    end
+
+    behaves_like 'A Rack::Cache::MetaStore Implementation'
+  end
+
 end

--- a/test/spec_setup.rb
+++ b/test/spec_setup.rb
@@ -1,6 +1,7 @@
 require 'pp'
 require 'tmpdir'
 require 'stringio'
+require 'active_support/cache'
 
 [STDOUT, STDERR].each { |io| io.sync = true }
 


### PR DESCRIPTION
A few of the Rails maintainers would like to move the rack-cache configuration out of Rails master and into the rack-cache gem. See the discussion at [#12365](https://github.com/rails/rails/pull/12365)

This PR does two things:

1. Adds a railtie that positions Rack::Cache at an appropriate place in the Rail's default middleware stack (after AD::Static, AD:SSL, and Rack::SendFile)

2. Copies the Rails entitystore and metastore classes that were previously inside of action_dispatch/http/rack_cache.rb. I updated the entitystore to take a ttl argument.

LMK what you think. Alternatively, this all could be placed into a rack-cache-rails gem.