### PR TITLE
Add a fault_tolerant flag to fail-over to stale cache.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source :rubygems
+gem 'rake', '~> 10.0'
 gemspec

--- a/README
+++ b/README
@@ -24,6 +24,10 @@ caching solution for small to medium sized deployments. More sophisticated /
 high-performance caching systems (e.g., Varnish, Squid, httpd/mod-cache) may be
 more appropriate for large deployments with significant throughput requirements.
 
+Rack::Cache includes an option to enable fault tolerant caching, so that stale
+cached results can be returned if the downstream service is unavailable.  Just
+set `:fault_tolerant => true` in the options hash.
+
 Installation
 ------------
 

--- a/lib/rack/cache/context.rb
+++ b/lib/rack/cache/context.rb
@@ -24,10 +24,6 @@ module Rack::Cache
     # The Rack application object immediately downstream.
     attr_reader :backend
 
-    # Set of exceptions that indicate a network connection failure.
-    # TODO: Make these configurable, to work in a non-faraday environment.
-    EXCEPTION_CLASSES = Set.new %w(Timeout::Error Faraday::Error::ConnectionFailed Faraday::Error::TimeoutError)
-
     def initialize(backend, options={})
       @backend = backend
       @trace = []

--- a/lib/rack/cache/options.rb
+++ b/lib/rack/cache/options.rb
@@ -107,6 +107,11 @@ module Rack::Cache
     # be used.
     option_accessor :use_native_ttl
 
+    # Specifies whether to serve a request from a stale cache entry if
+    # the attempt to revalidate that entry returns a connection
+    # failure or times out.
+    option_accessor :fault_tolerant
+
     # The underlying options Hash. During initialization (or outside of a
     # request), this is a default values Hash. During a request, this is the
     # Rack environment Hash. The default values Hash is merged in underneath
@@ -149,6 +154,7 @@ module Rack::Cache
         'rack-cache.allow_reload'     => false,
         'rack-cache.allow_revalidate' => false,
         'rack-cache.use_native_ttl'   => false,
+        'rack-cache.fault_tolerant'   => false,
       }
       self.options = options
     end

--- a/lib/rack/cache/response.rb
+++ b/lib/rack/cache/response.rb
@@ -146,7 +146,7 @@ module Rack::Cache
 
     # The age of the response.
     def age
-      (headers['Age'] ||  [(now - date).to_i, 0].max).to_i
+      [headers['Age'].to_i, (now - date).to_i].max
     end
 
     # The number of seconds after the time specified in the response's Date

--- a/rack-cache.gemspec
+++ b/rack-cache.gemspec
@@ -3,8 +3,8 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
 
   s.name = 'rack-cache'
-  s.version = '1.2'
-  s.date = '2012-03-05'
+  s.version = '1.3'
+  s.date = '2013-06-18'
 
   s.summary     = "HTTP Caching for Rack"
   s.description = "Rack::Cache is suitable as a quick drop-in component to enable HTTP caching for Rack-based applications that produce freshness (Expires, Cache-Control) and/or validation (Last-Modified, ETag) information."
@@ -66,6 +66,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bacon'
   s.add_development_dependency 'memcached'
   s.add_development_dependency 'dalli'
+  s.add_development_dependency 'pry'
 
   s.has_rdoc = true
   s.homepage = "http://rtomayko.github.com/rack-cache/"

--- a/test/spec_setup.rb
+++ b/test/spec_setup.rb
@@ -80,6 +80,20 @@ $LOAD_PATH.unshift File.dirname(__FILE__)
 
 require 'rack/cache'
 
+module Rack
+  class MockRequest
+    class << self
+      alias_method :new_env_for, :env_for
+    end
+    def self.env_for(uri="", opts={})
+      middleware_opts = opts.delete(:middleware_options)
+      ret_env = self.new_env_for(uri, opts)
+      ret_env[:middleware_options] = middleware_opts unless middleware_opts.nil?
+      ret_env
+    end
+  end
+end
+
 # Methods for constructing downstream applications / response
 # generators.
 module CacheContextHelpers


### PR DESCRIPTION
Rack::Cache includes an option to enable fault tolerant caching, so that stale cached results can be returned if the downstream service is unavailable.  Just set `:fault_tolerant => true` in the options hash.

All automated tests continue to pass.
