### PR TITLE
Enabling native ttl option for metastore

### DIFF
--- a/test/metastore_test.rb
+++ b/test/metastore_test.rb
@@ -251,6 +251,12 @@ shared 'A Rack::Cache::MetaStore Implementation' do
 
     @store.read(key).length.should.equal 2
   end
+
+  it 'takes a ttl parameter for #write' do
+    @store.write('/test', [[{},{}],[{},{}]], 0)
+    tuples = @store.read('/test')
+    tuples.should.equal [ [{},{}], [{},{}] ]
+  end
 end
 
 


### PR DESCRIPTION
If an EntityStore for a given entry was purged at the cache level--due to its native ttl--the corresponding MetaStore entry should be allowed to be purged as well.
