### PR TITLE
Not invalidating the cache for preflight CORS request

### DIFF
--- a/lib/rack/cache/context.rb
+++ b/lib/rack/cache/context.rb
@@ -60,14 +60,18 @@ module Rack::Cache
       @env = env
       @request = Request.new(@env.dup.freeze)
       response =
-        if @request.get? || @request.head? || @request.options?
+        if @request.get? || @request.head?
           if !@env['HTTP_EXPECT'] && !@env['rack-cache.force-pass']
             lookup
           else
             pass
           end
         else
-          invalidate
+          unless @request.options?
+            invalidate
+          else
+            pass
+          end
         end
 
       # log trace and set X-Rack-Cache tracing header

--- a/lib/rack/cache/context.rb
+++ b/lib/rack/cache/context.rb
@@ -59,6 +59,7 @@ module Rack::Cache
       @default_options.each { |k,v| env[k] ||= v }
       @env = env
       @request = Request.new(@env.dup.freeze)
+
       response =
         if @request.get? || @request.head?
           if !@env['HTTP_EXPECT'] && !@env['rack-cache.force-pass']

--- a/lib/rack/cache/context.rb
+++ b/lib/rack/cache/context.rb
@@ -59,9 +59,8 @@ module Rack::Cache
       @default_options.each { |k,v| env[k] ||= v }
       @env = env
       @request = Request.new(@env.dup.freeze)
-
       response =
-        if @request.get? || @request.head?
+        if @request.get? || @request.head? || @request.options?
           if !@env['HTTP_EXPECT'] && !@env['rack-cache.force-pass']
             lookup
           else

--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -27,7 +27,7 @@ describe 'Rack::Cache::Context' do
 
   it "passes on options requests" do
     respond_with 200
-    request "OPTIONS", '/'
+    request "options", '/'
 
     app.should.be.called
     response.should.be.ok

--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -37,6 +37,16 @@ describe 'Rack::Cache::Context' do
     end
   end
 
+  it "doesnt invalidate on options requests" do
+    respond_with 200
+    request "options", '/'
+
+    app.should.be.called
+    response.should.be.ok
+    cache.trace.should.not.include :invalidate
+    cache.trace.should.not.include :pass
+  end
+
   it 'does not cache with Authorization request header and non public response' do
     respond_with 200, 'ETag' => '"FOO"'
     get '/', 'HTTP_AUTHORIZATION' => 'basic foobarbaz'

--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -25,6 +25,24 @@ describe 'Rack::Cache::Context' do
     response.headers.should.not.include 'Age'
   end
 
+  it "passes on options requests" do
+    respond_with 200
+    request "OPTIONS", '/'
+
+    app.should.be.called
+    response.should.be.ok
+    cache.trace.should.include :pass
+  end
+
+  it "doesnt invalidate on options requests" do
+    respond_with 200
+    request "options", '/'
+
+    app.should.be.called
+    response.should.be.ok
+    cache.trace.should.not.include :invalidate
+  end
+
   %w[post put delete].each do |request_method|
     it "invalidates on #{request_method} requests" do
       respond_with 200
@@ -35,16 +53,6 @@ describe 'Rack::Cache::Context' do
       cache.trace.should.include :invalidate
       cache.trace.should.include :pass
     end
-  end
-
-  it "doesnt invalidate on options requests" do
-    respond_with 200
-    request "options", '/'
-
-    app.should.be.called
-    response.should.be.ok
-    cache.trace.should.not.include :invalidate
-    cache.trace.should.not.include :pass
   end
 
   it 'does not cache with Authorization request header and non public response' do


### PR DESCRIPTION
When making a CORS (http://www.w3.org/TR/cors/) request, first a preflight OPTIONS request is sent to ensure the request is valid. Once receiving a response from the OPTIONS request the real request is then made (so long as the OPTIONS response confirmed its validity) e.g.

some-origin sends => OPTIONS /foo/bar to some-other-origin
some-origin is allowed access to some-other-origin
some-origin sends => GET /foo/bar to some-other-origin

Currently the OPTIONS request is invalidating the /foo/bar cache and is rendering the cache useless for cross origin requests, such as using an AngularJS front end with a Sinatra JSON API.

I've put together a simple solution which checks for OPTIONS requests before invalidating the cache. The OPTIONS response isn't cached and is always passed.