### PR TITLE
Return nil for expires if the Expires header is not parseable.

### DIFF
--- a/lib/rack/cache/response.rb
+++ b/lib/rack/cache/response.rb
@@ -164,6 +164,8 @@ module Rack::Cache
     # The value of the Expires header as a Time object.
     def expires
       headers['Expires'] && Time.httpdate(headers['Expires'])
+    rescue ArgumentError
+      nil
     end
 
     # The number of seconds after which the response should no longer

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -190,4 +190,19 @@ describe 'Rack::Cache::Response' do
         ['Accept-Language', 'User-Agent', 'X-Foo']
     end
   end
+
+  describe '#expires' do
+    it 'returns nil if there is no Expires header' do
+      @res.headers['Expires'] = nil
+      @res.expires.should.be.nil
+    end
+    it 'returns a Time if the Expires header is parseable' do
+      @res.headers['Expires'] = "Mon, 30 Jun 2014 20:10:46 GMT"
+      @res.expires.should.equal Time.httpdate(@res.headers['Expires'])
+    end
+    it 'returns nil if the Expires header is not parseable' do
+      @res.headers['Expires'] = "Jun, 30 Mon 2014 20:10:46 GMT"
+      @res.expires.should.be.nil
+    end
+  end
 end


### PR DESCRIPTION
We encountered a site which had an Expires header which was unparseable by `Time.httpdate`. This caused `Time.httpdate` to raise [`ArgumentError: not RFC 2616 compliant date`](https://github.com/ruby/ruby/blob/v2_0_0_481/lib/time.rb#L509).

This PR makes `expires` return `nil` if the Expires header is not parseable.
