### PR TITLE
Fix key generation

### DIFF
--- a/lib/rack/cache/key.rb
+++ b/lib/rack/cache/key.rb
@@ -43,7 +43,7 @@ module Rack::Cache
       return nil if @request.query_string.nil?
 
       @request.query_string.split(/[&;] */n).
-        map { |p| unescape(p).split('=', 2) }.
+        map { |p| p.split('=', 2).map{ |s| unescape(s) } }.
         sort.
         map { |k,v| "#{escape(k)}=#{escape(v)}" }.
         join('&')

--- a/test/key_test.rb
+++ b/test/key_test.rb
@@ -19,6 +19,16 @@ describe 'A Rack::Cache::Key' do
     new_key(request).must_include('a=first&z=last')
   end
 
+  it "handles badly encoded params" do
+    request = mock_request('/test?%D0%BA=%D1')
+    new_key(request).must_include('%D0%BA=%D1')
+  end
+
+  it "doesn't confuse encoded equals sign with query string separator" do
+    request = mock_request('/test?weird%3Dkey=whatever')
+    new_key(request).must_include('weird%3Dkey=whatever')
+  end
+
   it "includes the scheme" do
     request = mock_request(
       '/test',


### PR DESCRIPTION
Query string keys must be escaped after the split bacause:
- Query string could look like 'weird%3Dkey=whatever'
- Rake util's unescape method forces utf-8 encoding on strings, which will cause the "invalid byte sequence in UTF-8" error for the most string methods called on badly encoded strings, e.g. Rack::Utils::unescape('%D0%BA=%D1').split('=')