### PR TITLE
Support Accept and Accept Encoding

### DIFF
--- a/lib/rack/cache/key.rb
+++ b/lib/rack/cache/key.rb
@@ -25,6 +25,14 @@ module Rack::Cache
         parts << ":" << @request.port.to_s
       end
 
+      if @request.env['HTTP_ACCEPT_ENCODING']
+        parts << @request.env['HTTP_ACCEPT_ENCODING']
+      end
+
+      if @request.env['HTTP_ACCEPT']
+        parts << @request.env['HTTP_ACCEPT']
+      end
+
       parts << @request.script_name
       parts << @request.path_info
 

--- a/test/key_test.rb
+++ b/test/key_test.rb
@@ -46,6 +46,16 @@ describe Rack::Cache::Key do
     new_key(request).must_include('/test')
   end
 
+  it "includes accept" do
+    request = mock_request('/test', 'HTTP_ACCEPT' => 'application/json')
+    new_key(request).should.include('application/json')
+  end
+
+  it "includes accept encoding" do
+    request = mock_request('/test', 'HTTP_ACCEPT_ENCODING' => 'gzip, deflate')
+    new_key(request).should.include('gzip, deflate')
+  end
+
   it "sorts the query string by key/value after decoding" do
     request = mock_request('/test?x=q&a=b&%78=c')
     new_key(request).must_match(/\?a=b&x=c&x=q$/)

--- a/test/key_test.rb
+++ b/test/key_test.rb
@@ -48,12 +48,12 @@ describe Rack::Cache::Key do
 
   it "includes accept" do
     request = mock_request('/test', 'HTTP_ACCEPT' => 'application/json')
-    new_key(request).should.include('application/json')
+    new_key(request).must_include('application/json')
   end
 
   it "includes accept encoding" do
     request = mock_request('/test', 'HTTP_ACCEPT_ENCODING' => 'gzip, deflate')
-    new_key(request).should.include('gzip, deflate')
+    new_key(request).must_include('gzip, deflate')
   end
 
   it "sorts the query string by key/value after decoding" do


### PR DESCRIPTION
This PR adds 'Accept' and 'Accept-Encoding' to the default Key implementation for Rack Cache.

I think having these two values as part of the cache key as a standard implementation is important due to the way Rails supports multiple format requests. Both ```curl -X GET /foo/bar.json``` and ```curl -X GET -H 'Accept: application/json /foo/bar' are pretty much the same thing and will land in the same handler in the controller.

However Key will work with ```bar.json``` vs ```bar``` since it considers the path but it will not distinguish between Accept ```application/json``` vs ```text/html```. 

Allowing this PR in, or some form of it, let's Rack Cache to be consistent with Rails behavior. As of now, without this, we're pretty much insuring that everyone will need to implement their own Key if they use HTTP cache directives.