### PR TITLE
Metastore TTL support

### DIFF
--- a/doc/configuration.markdown
+++ b/doc/configuration.markdown
@@ -127,9 +127,10 @@ For more options see the [Rack::Request documentation](http://rack.rubyforge.org
 
 ### `use_native_ttl`
 
-Passes on the expiration timestamp to the cache store. This may be necessary
-with some stores to keep them from filling up, e.g. if using a Redis backend and
-the `volatile-ttl` expiration policy.
+Passes on the expiration timestamp to cache stores that support it, like
+Memcache and Redis. This may be necessary with some stores to keep them from
+filling up, e.g. if using a Redis backend and the `volatile-ttl` expiration
+policy.
 
 If using `memcached`, it will speed up misses slightly as the middleware won't
 need to fetch metadata and check timestamps.

--- a/doc/configuration.markdown
+++ b/doc/configuration.markdown
@@ -124,4 +124,13 @@ which will act as the cache key generator:
 	end
 	
 For more options see the [Rack::Request documentation](http://rack.rubyforge.org/doc/classes/Rack/Request.html)
-	
+
+### `use_native_ttl`
+
+Passes on the expiration timestamp to the cache store. This may be necessary
+with some stores to keep them from filling up, e.g. if using a Redis backend and
+the `volatile-ttl` expiration policy.
+
+If using `memcached`, it will speed up misses slightly as the middleware won't
+need to fetch metadata and check timestamps.
+

--- a/lib/rack/cache/meta_store.rb
+++ b/lib/rack/cache/meta_store.rb
@@ -81,7 +81,7 @@ module Rack::Cache
       headers.delete 'Age'
 
       entries.unshift [stored_env, headers]
-      if request.env['rack-cache.use_native_ttl']
+      if request.env['rack-cache.use_native_ttl'] && response.fresh?
         write key, entries, response.ttl
       else
         write key, entries

--- a/lib/rack/cache/meta_store.rb
+++ b/lib/rack/cache/meta_store.rb
@@ -329,6 +329,7 @@ module Rack::Cache
         cache.get(key) || []
       end
 
+      # Default TTL to zero, interpreted as "don't expire" by Memcached.
       def write(key, entries, ttl = 0)
         key = hexdigest(key)
         cache.set(key, entries, ttl)
@@ -363,6 +364,7 @@ module Rack::Cache
         []
       end
 
+      # Default TTL to zero, interpreted as "don't expire" by Memcached.
       def write(key, entries, ttl = 0)
         key = hexdigest(key)
         cache.set(key, entries, ttl)

--- a/test/meta_store_test.rb
+++ b/test/meta_store_test.rb
@@ -253,6 +253,12 @@ module RackCacheMetaStoreImplementation
 
         @store.read(key).length.must_equal 2
       end
+
+      it 'takes a ttl parameter for #write' do
+        @store.write('/test', [[{},{}],[{},{}]], 0)
+        tuples = @store.read('/test')
+        tuples.must_equal [ [{},{}], [{},{}] ]
+      end
     end
   end
 end

--- a/test/meta_store_test.rb
+++ b/test/meta_store_test.rb
@@ -114,6 +114,12 @@ module RackCacheMetaStoreImplementation
         store_simple_entry('/bad', { 'SOME_THING' => Proc.new {} })
       end
 
+      it 'supports a ttl parameter for #write' do
+        @store.write('/test', [[{},{}],[{},{}]], 0)
+        tuples = @store.read('/test')
+        tuples.must_equal [ [{},{}], [{},{}] ]
+      end
+
       # Abstract methods ===========================================================
 
       it 'stores a cache entry' do
@@ -254,10 +260,30 @@ module RackCacheMetaStoreImplementation
         @store.read(key).length.must_equal 2
       end
 
-      it 'takes a ttl parameter for #write' do
-        @store.write('/test', [[{},{}],[{},{}]], 0)
-        tuples = @store.read('/test')
-        tuples.must_equal [ [{},{}], [{},{}] ]
+      # TTL ====================================================================
+
+      context 'logging writes' do
+        write_intercept = Module.new do
+          attr_reader :last_write
+
+          def write(*args)
+            @last_write = args
+            super
+          end
+        end
+
+        before do
+          @entity_store.extend(write_intercept)
+          @store.extend(write_intercept)
+        end
+
+        it 'passes a TTL to the stores is use_native_ttl is truthy' do
+          req1 = mock_request('/test', { 'rack-cache.use_native_ttl' => true })
+          res1 = mock_response(200, {'Cache-Control' => 'max-age=42'}, ['foo'])
+          @store.store(req1, res1, @entity_store)
+          @entity_store.last_write.must_equal [['foo'], 42]
+          @store.last_write[2].must_equal 42
+        end
       end
     end
   end


### PR DESCRIPTION
This contains #92 and #93, adds travis build configuration, adds missing docs for `use_native_ttl`, and cleans up the Rakefile.

@rtomayko if you're too busy I'm happy to help maintain this, just let me know.