### PR TITLE
Add back ruby 1.9.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ branches:
   only: master
 
 rvm:
+  - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1.7

--- a/rack-cache.gemspec
+++ b/rack-cache.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new 'rack-cache', '1.5.1' do |s|
   s.summary     = "HTTP Caching for Rack"
   s.description = "Rack::Cache is suitable as a quick drop-in component to enable HTTP caching for Rack-based applications that produce freshness (Expires, Cache-Control) and/or validation (Last-Modified, ETag) information."
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 1.9.2'
 
   s.authors = ["Ryan Tomayko"]
   s.email = "r@tomayko.com"


### PR DESCRIPTION
Version 1.3.1 lists Ruby 1.9 support, but ruby 1.9.2 was excluded.

Currently our travis ci build matrix with rails 3.1 and rails 3.2 on ruby 1.9.2 fails due to the ruby 1.9.3 requirement pulled in through rack-cache.