### PR TITLE
Allow setting the entity store to nil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 \[.
 tags
 .vimrc
-.idea
 /dist
 /pkg
 /coverage

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ tags
 .vimrc
 .idea
 /dist
+/pkg
 /coverage
 /doc/api
 /doc/*.png

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 \[.
 tags
 .vimrc
+.idea
 /dist
 /coverage
 /doc/api

--- a/lib/rack/cache/context.rb
+++ b/lib/rack/cache/context.rb
@@ -38,7 +38,11 @@ module Rack::Cache
     # value effects the result of this method immediately.
     def entitystore
       uri = options['rack-cache.entitystore']
-      storage.resolve_entitystore_uri(uri)
+      if uri.nil?
+        return nil
+      else
+        storage.resolve_entitystore_uri(uri)
+      end
     end
 
     # The Rack call interface. The receiver acts as a prototype and runs

--- a/lib/rack/cache/context.rb
+++ b/lib/rack/cache/context.rb
@@ -38,11 +38,7 @@ module Rack::Cache
     # value effects the result of this method immediately.
     def entitystore
       uri = options['rack-cache.entitystore']
-      if uri.nil?
-        return nil
-      else
-        storage.resolve_entitystore_uri(uri)
-      end
+      storage.resolve_entitystore_uri(uri) if uri
     end
 
     # The Rack call interface. The receiver acts as a prototype and runs

--- a/lib/rack/cache/metastore.rb
+++ b/lib/rack/cache/metastore.rb
@@ -64,7 +64,7 @@ module Rack::Cache
       # write the response body to the entity store if this is the
       # original response.
       if response.headers['X-Content-Digest'].nil?
-        unless entity_store.nil?
+        if entity_store
           if request.env['rack-cache.use_native_ttl'] && response.fresh?
             digest, size = entity_store.write(response.body, response.ttl)
           else


### PR DESCRIPTION
This PR adds the ability to set rack-cache entity store to nil, e.g.:

```
require 'rack/cache'

use Rack::Cache,
  :metastore   => 'file:/var/cache/rack/meta',
  :entitystore => nil,
  :verbose     => true

run app
```

When ```entitystore``` is set to nil, rack-cache doesn't persist response bodies. If a cached response is still fresh, or if it's stale but found to be still valid, rack-cache returns only the response headers with an empty body. The code performing the request should check if the response comes from the cache (e.g. checking the ```X-Rack-Cache``` header) and in in this case ignore the response body.

Obviously this is only useful for use cases in which, if a cached response is still valid, its body is not interesting.

This is useful for my particular use case but may be interesting for other people. In particular this avoids the common problem of the backend (disk in my case) filling up with old entities, because rack-cache performs no cleanup of old useless entities once there is a new response. This can be avoided with this PR by not persisting entries in the backend in the first place.