### PR TITLE
Added a new Dummy backend for Entity Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,43 @@ use Rack::Cache,
 run app
 ```
 
+Using the Noop backend for the entity store
+-------------------------------------------
+
+The Noop backend can be used for the entity store if you're not interested in the bodies of cached 
+responses. This backend does not actually persist response bodies, so no memory or disk space has 
+to be allocated for them (the metastore backend still needs those resources). 
+
+Be careful: when using this backend, responses retrieved from the cache always have an empty body. You must 
+check if the response comes from the cache (by looking at the presence of 'fresh' or 'valid' in the 
+```X-Rack-Cache``` HTTP header) and in this case you should ignore the response body.
+ 
+There are two ways of configuring rack-cache to use this backend:
+ 
+```Ruby
+require 'rack/cache'
+
+use Rack::Cache,
+ :verbose => true,
+ :metastore   => "file:/var/cache/rack/meta", # you can use any backend here
+ :entitystore => nil
+
+run app
+```
+
+or
+
+```Ruby
+require 'rack/cache'
+
+use Rack::Cache,
+ :verbose => true,
+ :metastore   => "file:/var/cache/rack/meta", # you can use any backend here
+ :entitystore => "noop://"
+
+run app
+```
+
 License: MIT<br/>
 [![Build Status](https://travis-ci.org/rtomayko/rack-cache.png)](https://travis-ci.org/rtomayko/rack-cache)
 

--- a/lib/rack/cache/entitystore.rb
+++ b/lib/rack/cache/entitystore.rb
@@ -336,8 +336,8 @@ module Rack::Cache
     GAECACHE = GAEStore
     GAE = GAEStore
 
-    # Dummy Entity Store backend that does not persist entities.
-    # When this entity store is used (by setting the entitystore option to nil or to a 'dummy:' URL),
+    # Noop Entity Store backend that does not persist entities.
+    # When this entity store is used (by setting the entitystore option to nil or to a 'noop:' URL),
     # response bodies will not be persisted. Responses retrieved from the cache will have an empty body.
     #
     # This backend is only useful for use cases in which the bodies of responses retrieved from the cache are of
@@ -345,7 +345,7 @@ module Rack::Cache
     # the X-Rack-Cache header in the response) and in this case ignore the response body.
     #
     # Using this backend means that no space must be allocated in disk or memory to store response bodies.
-    class Dummy < EntityStore
+    class Noop < EntityStore
       def exist?(key)
         true
       end
@@ -373,8 +373,8 @@ module Rack::Cache
       end
     end
 
-    NIL = Dummy
-    DUMMY = Dummy
+    NIL = Noop
+    NOOP = Noop
 
   end
 

--- a/lib/rack/cache/entitystore.rb
+++ b/lib/rack/cache/entitystore.rb
@@ -336,7 +336,15 @@ module Rack::Cache
     GAECACHE = GAEStore
     GAE = GAEStore
 
-    # Dummy Entity Store that does not persist entities
+    # Dummy Entity Store backend that does not persist entities.
+    # When this entity store is used (by setting the entitystore option to nil or to a 'dummy:' URL),
+    # response bodies will not be persisted. Responses retrieved from the cache will have an empty body.
+    #
+    # This backend is only useful for use cases in which the bodies of responses retrieved from the cache are of
+    # no interest. The code making the request MUST check if the response comes from the cache (e.g. looking at
+    # the X-Rack-Cache header in the response) and in this case ignore the response body.
+    #
+    # Using this backend means that no space must be allocated in disk or memory to store response bodies.
     class Dummy < EntityStore
       def exist?(key)
         true

--- a/lib/rack/cache/entitystore.rb
+++ b/lib/rack/cache/entitystore.rb
@@ -351,11 +351,11 @@ module Rack::Cache
       end
 
       def read(key)
-        nil
+        ''
       end
 
       def open(key)
-        nil
+        []
       end
 
       def write(body, ttl=nil)

--- a/lib/rack/cache/entitystore.rb
+++ b/lib/rack/cache/entitystore.rb
@@ -336,6 +336,38 @@ module Rack::Cache
     GAECACHE = GAEStore
     GAE = GAEStore
 
+    # Dummy Entity Store that does not persist entities
+    class Dummy < EntityStore
+      def exist?(key)
+        true
+      end
+
+      def read(key)
+        nil
+      end
+
+      def open(key)
+        nil
+      end
+
+      def write(body, ttl=nil)
+        key=''
+        size = 0
+        [key, size]
+      end
+
+      def purge(key)
+        nil
+      end
+
+      def self.resolve(uri)
+        new
+      end
+    end
+
+    NIL = Dummy
+    DUMMY = Dummy
+
   end
 
 end

--- a/lib/rack/cache/entitystore.rb
+++ b/lib/rack/cache/entitystore.rb
@@ -359,8 +359,7 @@ module Rack::Cache
       end
 
       def write(body, ttl=nil)
-        key=''
-        size = 0
+        key, size = slurp(body) { |part| part }
         [key, size]
       end
 

--- a/lib/rack/cache/metastore.rb
+++ b/lib/rack/cache/metastore.rb
@@ -122,7 +122,7 @@ module Rack::Cache
 
     # Converts a stored response hash into a Response object. The caller
     # is responsible for loading and passing the body if needed.
-    def restore_response(hash, body=nil)
+    def restore_response(hash, body=[])
       status = hash.delete('X-Status').to_i
       Rack::Cache::Response.new(status, hash, body)
     end

--- a/lib/rack/cache/metastore.rb
+++ b/lib/rack/cache/metastore.rb
@@ -40,7 +40,8 @@ module Rack::Cache
       _, res = match
 
       body = entity_store.open(res['X-Content-Digest'])
-      if body || entity_store.is_a?(Rack::Cache::EntityStore::Dummy)
+      # It is not an error to get a nil body from a Noop backend, because it doesn't persist bodies.
+      if body || entity_store.is_a?(Rack::Cache::EntityStore::Noop)
         restore_response(res, body)
       else
         # TODO the metastore referenced an entity that doesn't exist in

--- a/lib/rack/cache/metastore.rb
+++ b/lib/rack/cache/metastore.rb
@@ -38,7 +38,9 @@ module Rack::Cache
       return nil if match.nil?
 
       _, res = match
-      if body = entity_store.open(res['X-Content-Digest'])
+
+      body = entity_store.open(res['X-Content-Digest'])
+      if body || entity_store.is_a?(Rack::Cache::EntityStore::Dummy)
         restore_response(res, body)
       else
         # TODO the metastore referenced an entity that doesn't exist in
@@ -122,6 +124,7 @@ module Rack::Cache
     # Converts a stored response hash into a Response object. The caller
     # is responsible for loading and passing the body if needed.
     def restore_response(hash, body=nil)
+      body = [] if body.nil?
       status = hash.delete('X-Status').to_i
       Rack::Cache::Response.new(status, hash, body)
     end

--- a/lib/rack/cache/storage.rb
+++ b/lib/rack/cache/storage.rb
@@ -38,6 +38,9 @@ module Rack::Cache
         else
           fail "Unknown storage provider: #{uri.to_s}"
         end
+      elsif uri.nil?
+        # hack to support setting entitystore to nil, which doesn't persist request bodies
+        type.const_get('NIL').resolve(uri)
       else
         # hack in support for passing a Dalli::Client or Memcached object
         # as the storage URI.

--- a/lib/rack/cache/storage.rb
+++ b/lib/rack/cache/storage.rb
@@ -40,7 +40,7 @@ module Rack::Cache
         end
       elsif uri.nil?
         # hack to support setting entitystore to nil, which doesn't persist request bodies
-        type.const_get('NIL').resolve(uri)
+        type.const_get(uri.inspect.upcase).resolve(uri)
       else
         # hack in support for passing a Dalli::Client or Memcached object
         # as the storage URI.

--- a/lib/rack/cache/storage.rb
+++ b/lib/rack/cache/storage.rb
@@ -40,7 +40,7 @@ module Rack::Cache
         end
       elsif uri.nil?
         # hack to support setting entitystore to nil, which doesn't persist request bodies
-        type.const_get(uri.inspect.upcase).resolve(uri)
+        type.const_get(nil.inspect.upcase).resolve(uri)
       else
         # hack in support for passing a Dalli::Client or Memcached object
         # as the storage URI.

--- a/test/entitystore_test.rb
+++ b/test/entitystore_test.rb
@@ -284,13 +284,13 @@ describe 'Rack::Cache::EntityStore' do
     it 'accepts bodies with #write' do
       key, size = @store.write(['My wild love went riding,'])
       refute key.nil?
-      assert key.sha_like?
+      assert key.length == 40 && key =~ /^[0-9a-z]+$/
     end
 
     it 'takes a ttl parameter for #write' do
       key, size = @store.write(['My wild love went riding,'], 0)
       refute key.nil?
-      assert key.sha_like?
+      assert key.length == 40 && key =~ /^[0-9a-z]+$/
     end
 
     it 'always responds to #exist? with true, regardless of the content having been saved before' do

--- a/test/entitystore_test.rb
+++ b/test/entitystore_test.rb
@@ -299,12 +299,12 @@ describe 'Rack::Cache::EntityStore' do
       assert @store.exist? '938jasddj83jasdh4438021ksdfjsdfjsdsf'
     end
 
-    it 'always responds to #read with nil' do
+    it 'always responds to #read with an empty String' do
       key, size = @store.write(['And asked him to pay.'])
       data = @store.read(key)
-      data.must_equal nil
+      data.must_equal ''
       data = @store.read('938jasddj83jasdh4438021ksdfjsdfjsdsf')
-      data.must_equal nil
+      data.must_equal ''
     end
 
     it 'gives a 40 character SHA1 hex digest from #write' do
@@ -315,18 +315,24 @@ describe 'Rack::Cache::EntityStore' do
       key.must_equal '90a4c84d51a277f3dafc34693ca264531b9f51b6'
     end
 
-    it 'always responds to #open with nil' do
+    it 'always responds to #open with empty array' do
       key, size = @store.write(['And asked him to pay.'])
       data = @store.open(key)
-      data.must_equal nil
-      data = @store.read('938jasddj83jasdh4438021ksdfjsdfjsdsf')
-      data.must_equal nil
+      data.must_equal []
+      data = @store.open('938jasddj83jasdh4438021ksdfjsdfjsdsf')
+      data.must_equal []
+    end
+
+    it 'returns a Rack compatible body from #open' do
+      key, size = @store.write(['Some shells for her hair.'])
+      body = @store.open(key)
+      assert body.respond_to? :each
+      body.must_equal []
     end
 
     it 'responds to #purge and returns nil' do
       key, size = @store.write(['My wild love went riding,'])
       @store.purge(key).must_equal nil
-      @store.read(key).must_equal nil
     end
   end
 end

--- a/test/entitystore_test.rb
+++ b/test/entitystore_test.rb
@@ -269,5 +269,64 @@ describe 'Rack::Cache::EntityStore' do
       end
       include RackCacheEntityStoreImplementation
     end
+
+  end
+
+  describe 'Noop' do
+    before {@store = Rack::Cache::EntityStore::Noop.new}
+
+    it 'responds to all required messages' do
+      %w[read open write exist?].each do |message|
+        assert @store.respond_to? message
+      end
+    end
+
+    it 'accepts bodies with #write' do
+      key, size = @store.write(['My wild love went riding,'])
+      refute key.nil?
+      assert key.sha_like?
+    end
+
+    it 'takes a ttl parameter for #write' do
+      key, size = @store.write(['My wild love went riding,'], 0)
+      refute key.nil?
+      assert key.sha_like?
+    end
+
+    it 'always responds to #exist? with true, regardless of the content having been saved before' do
+      key, size = @store.write(['She rode to the devil,'])
+      assert @store.exist? key
+      assert @store.exist? '938jasddj83jasdh4438021ksdfjsdfjsdsf'
+    end
+
+    it 'always responds to #read with nil' do
+      key, size = @store.write(['And asked him to pay.'])
+      data = @store.read(key)
+      data.must_equal nil
+      data = @store.read('938jasddj83jasdh4438021ksdfjsdfjsdsf')
+      data.must_equal nil
+    end
+
+    it 'gives a 40 character SHA1 hex digest from #write' do
+      key, size = @store.write(['she rode to the sea;'])
+      refute key.nil?
+      key.length.must_equal 40
+      key.must_match /^[0-9a-z]+$/
+      key.must_equal '90a4c84d51a277f3dafc34693ca264531b9f51b6'
+    end
+
+    it 'always responds to #open with nil' do
+      key, size = @store.write(['And asked him to pay.'])
+      data = @store.open(key)
+      data.must_equal nil
+      data = @store.read('938jasddj83jasdh4438021ksdfjsdfjsdsf')
+      data.must_equal nil
+    end
+
+    it 'responds to #purge and returns nil' do
+      key, size = @store.write(['My wild love went riding,'])
+      @store.purge(key).must_equal nil
+      @store.read(key).must_equal nil
+    end
   end
 end


### PR DESCRIPTION
This PR adds the ability to set rack-cache entity store to nil, e.g.:
```
require 'rack/cache'

use Rack::Cache,
  :metastore   => 'file:/var/cache/rack/meta',
  :entitystore => nil,
  :verbose     => true

run app
```
or
```
require 'rack/cache'

use Rack::Cache,
  :metastore   => 'file:/var/cache/rack/meta',
  :entitystore => 'dummy:',
  :verbose     => true

run app
```

Both values (nil or 'dummy:') in the entitystore option enable the Dummy backend.

When the Dummy backend is used for the entity store, rack-cache doesn't persist response bodies. If a cached response is still fresh, or if it's stale but found to be still valid, rack-cache returns only the response headers with an empty body. The code performing the request should check if the response comes from the cache (e.g. checking the X-Rack-Cache header) and in in this case ignore the response body.

Obviously this is only useful for use cases in which, if a cached response is still valid, its body is not interesting.

This is useful for my particular use case but may be interesting for other people. In particular this avoids the common problem of the backend (disk in my case) filling up with old entities, because rack-cache performs no cleanup of old useless entities once there is a new response. This can be avoided with this PR by not persisting entries in the backend in the first place.