### PR TITLE
read from cache to deal with streamed bodies correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ Noop entity store
 
 Does not persist response bodies (no disk/memory used).<br/>
 Responses from the cache will have an empty body.<br/>
-Clients must ignore these empty cached response (check for X-Rack-Cache response header).
+Clients must ignore these empty cached response (check for X-Rack-Cache response header).<br/>
+Atm cannot handle streamed responses, patch needed.
  
 ```Ruby
 require 'rack/cache'

--- a/lib/rack/cache/entity_store.rb
+++ b/lib/rack/cache/entity_store.rb
@@ -342,6 +342,7 @@ module Rack::Cache
     # Does not persist response bodies (no disk/memory used).
     # Responses from the cache will have an empty body.
     # Clients must ignore these empty cached response (check for X-Rack-Cache response header).
+    # Atm cannot handle streamed responses, patch needed.
     #
     class Noop < EntityStore
       def exist?(key)

--- a/lib/rack/cache/meta_store.rb
+++ b/lib/rack/cache/meta_store.rb
@@ -64,6 +64,8 @@ module Rack::Cache
         end
         response.headers['X-Content-Digest'] = digest
         response.headers['Content-Length'] = size.to_s unless response.headers['Transfer-Encoding']
+        # If the entitystore backend is a Noop, do not try to read the body from the backend, it always returns an empty array
+        response.body = entity_store.open(digest) || response.body unless entity_store.is_a? Rack::Cache::EntityStore::Noop
       end
 
       # read existing cache entries, remove non-varying, and add this one to

--- a/test/meta_store_test.rb
+++ b/test/meta_store_test.rb
@@ -33,7 +33,7 @@ module RackCacheMetaStoreImplementation
         @response = mock_response(200, {'Cache-Control' => 'max-age=420'}, ['test'])
         body = @response.body
         cache_key = @store.store(@request, @response, @entity_store)
-        @response.body.object_id.must_equal body.object_id
+        @response.body.object_id.wont_equal body.object_id
         cache_key
       end
 


### PR DESCRIPTION
streamed bodies can only be read once, so we cannot read them and then return them
hotfix for 1.6.0 release ... need a bit more time and a minor release to implement a proper fix

reverts https://github.com/rtomayko/rack-cache/pull/133
fixes https://github.com/rtomayko/rack-cache/issues/134

review plz: @alau @amatriain @krisdigital 

TODO:
make write return the read body and then return that, except for cases where that might be inefficient like Disk store