### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,15 @@ branches:
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.7
-  - 2.2.3
+  - 2.1.10
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
+  - ruby-head
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+  fast_finish: true
 before_install:
  - gem update --system
  - gem install bundler --no-ri --no-rdoc


### PR DESCRIPTION
I updated Rubies to latest version on .travis.yml.

I also added ruby-head to Travis as allow_failures.

I think this is useful.
Because we can prepare before next version Ruby 2.5 release.
Though it might not be useful until the actual preview release.
We can support the next version as faster.

We can see this kind of logic in `rails`, `rspec` and `cucumber` and etc.

https://github.com/rails/rails/blob/master/.travis.yml
https://github.com/rspec/rspec-core/blob/master/.travis.yml
https://github.com/cucumber/cucumber-ruby/blob/master/.travis.yml

Is it possible to merge it?

Thanks.
