### PR TITLE
Return current date if the Date header is not parseable.

### DIFF
--- a/lib/rack/cache/response.rb
+++ b/lib/rack/cache/response.rb
@@ -133,8 +133,8 @@ module Rack::Cache
       headers['Age'] = max_age.to_s if fresh?
     end
 
-    # The date, as specified by the Date header. When no Date header is present,
-    # set the Date header to Time.now and return.
+    # The date, as specified by the Date header. When no Date header is present
+    # or is unparseable, set the Date header to Time.now and return.
     def date
       if date = headers['Date']
         Time.httpdate(date)
@@ -142,6 +142,9 @@ module Rack::Cache
         headers['Date'] = now.httpdate unless headers.frozen?
         now
       end
+    rescue ArgumentError
+      headers['Date'] = now.httpdate unless headers.frozen?
+      now
     end
 
     # The age of the response.

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -54,9 +54,13 @@ describe Rack::Cache::Response do
   end
 
   describe '#date' do
-    it 'uses the Date header if present' do
+    it 'uses the Date header if present and parseable' do
       @res = Rack::Cache::Response.new(200, {'Date' => @one_hour_ago.httpdate}, [])
       @res.date.must_equal @one_hour_ago
+    end
+    it 'returns the current time if present but not parseable' do
+      @res = Rack::Cache::Response.new(200, {'Date' => "Jun, 30 Mon 2014 20:10:46 GMT"}, [])
+      @res.date.to_i.must_be_close_to Time.now.to_i, 1
     end
     it 'uses the current time when no Date header present' do
       @res = Rack::Cache::Response.new(200, {}, [])


### PR DESCRIPTION
PR https://github.com/rtomayko/rack-cache/pull/97 (which is merged) fixed an issue in which a date in the Expires header that did not conform to RFC 2616 caused the whole request to fail with an ArgumentError. 

However the fix should also be applied to the Date header. If Date has a value like "Sat, 2 Sep 2017 03:06:10 GMT" the request will fail because this date is not parseable according to the RFC2616 format (the month should have two digits, with a leading zero if necessary, so a correct value would be "Sat, 02 Sep 2017 03:06:10 GMT"). In the case of the Date header, if an ArgumentError is raised when parsing it, the current date should be returned, same as if the header is not present.