### PR TITLE
Readme: fixed rails integration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,15 @@ caching.
 Using with Rails
 ----------------
 
-Either of these but not both:
-
 ```Ruby
 # config/application.rb
 config.action_dispatch.rack_cache = true
 # or
-config.middleware.use Rack::Cache,
+config.action_dispatch.rack_cache = {
    verbose:     true,
    metastore:   'file:/var/cache/rack/meta',
    entitystore: 'file:/var/cache/rack/body'
+}
 ```
 
 You should now see `Rack::Cache` listed in the middleware pipeline:


### PR DESCRIPTION
`config.middleware.use` inserts the middleware into a wrong place in the stack. As a result Rails' `ConditionalGet` turns all responses that are served from cache into 304s (blank pages for users).