### PR TITLE
bump ruby requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache: bundler
 branches:
   only: master
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.10
   - 2.2.7

--- a/rack-cache.gemspec
+++ b/rack-cache.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new 'rack-cache', '1.7.1' do |s|
   s.summary     = "HTTP Caching for Rack"
   s.description = "Rack::Cache is suitable as a quick drop-in component to enable HTTP caching for Rack-based applications that produce freshness (Expires, Cache-Control) and/or validation (Last-Modified, ETag) information."
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.0.0'
 
   s.authors = ["Ryan Tomayko"]
   s.email = "r@tomayko.com"


### PR DESCRIPTION
travis fails because of a ruby 1.9 bug in minitest-line https://travis-ci.org/rtomayko/rack-cache/jobs/346354873

... time to drop 1.9 ? (old versions can still be used)

@rtomayko @amatriain @rmm5t 