### PR TITLE
Query string empty string

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+## 1.7.2
+
+  * fix key generation for requests with no query strings
+
 ## 1.7.0
 
   * Meta stores now receive a third ttl argument to write when use_native_ttl is used.

--- a/lib/rack/cache/key.rb
+++ b/lib/rack/cache/key.rb
@@ -40,7 +40,7 @@ module Rack::Cache
     # Build a normalized query string by alphabetizing all keys/values
     # and applying consistent escaping.
     def query_string
-      return nil if @request.query_string.nil?
+      return nil if @request.query_string.to_s.empty?
 
       @request.query_string.split(/[&;] */n).
         map { |p| p.split('=', 2).map{ |s| unescape(s) } }.

--- a/rack-cache.gemspec
+++ b/rack-cache.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new 'rack-cache', '1.7.1' do |s|
+Gem::Specification.new 'rack-cache', '1.7.2' do |s|
   s.summary     = "HTTP Caching for Rack"
   s.description = "Rack::Cache is suitable as a quick drop-in component to enable HTTP caching for Rack-based applications that produce freshness (Expires, Cache-Control) and/or validation (Last-Modified, ETag) information."
   s.required_ruby_version = '>= 2.0.0'

--- a/test/key_test.rb
+++ b/test/key_test.rb
@@ -46,6 +46,11 @@ describe Rack::Cache::Key do
     new_key(request).must_include('/test')
   end
 
+  it "does not include question mark if there is no query string" do
+    request = mock_request('/test')
+    new_key(request).wont_include('?')
+  end
+
   it "sorts the query string by key/value after decoding" do
     request = mock_request('/test?x=q&a=b&%78=c')
     new_key(request).must_match(/\?a=b&x=c&x=q$/)


### PR DESCRIPTION
Rack uses `to_s` in the `query_string` method, meaning `nil` will be converted to an empty string. However, when checking for the presence of the query string, Rack::Cache uses `.nil?`. As a result, Rack::Cache currently appends '?' to cache keys, even if the request does not include a query string.

Here is the relevant code in Rack: https://github.com/rack/rack/blob/master/lib/rack/request.rb#L136