### PR TITLE
Warn once on X-Content-Digest entity store miss

### DIFF
--- a/lib/rack/cache/meta_store.rb
+++ b/lib/rack/cache/meta_store.rb
@@ -46,7 +46,11 @@ module Rack::Cache
         begin
           purge(key)
         rescue NotImplementedError
-          warn_once('purge') { "WARNING: Future releases may require purge implementation for #{self.class.name}" }
+          @@warned_on_purge ||= begin
+            warn "WARNING: Future releases may require purge implementation for #{self.class.name}"
+            true
+          end
+          nil
         end
       end
     end
@@ -159,19 +163,6 @@ module Rack::Cache
         key = "HTTP_#{header.upcase.tr('-', '_')}"
         env1[key] == env2[key]
       end
-    end
-
-    @@warned_keys = { }
-    # Log a warning message once. For example, deprecation messages.
-    # Warnings will be displayed once per key and self.class combination.
-    # The warning message is only retrieved from the block if a warning
-    # should be displayed.
-    def warn_once(key)
-      lookup_key = "#{self.class.name}:#{key}"
-      return if @@warned_keys[lookup_key]
-      warn yield if block_given?
-      @@warned_keys[lookup_key] = true
-      nil
     end
 
   protected

--- a/test/meta_store_test.rb
+++ b/test/meta_store_test.rb
@@ -192,7 +192,7 @@ module RackCacheMetaStoreImplementation
 
       it 'warns once if purge is not implemented' do
         store_simple_entry
-        refute @response.headers['X-Content-Digest'].nil?
+        assert @response.headers['X-Content-Digest']
         @entity_store.purge(@response.headers['X-Content-Digest'])
         def @store.purge(key); raise NotImplementedError; end
         @store.lookup(@request, @entity_store).must_be_nil

--- a/test/meta_store_test.rb
+++ b/test/meta_store_test.rb
@@ -190,6 +190,15 @@ module RackCacheMetaStoreImplementation
         mock.verify
       end
 
+      it 'warns once if purge is not implemented' do
+        store_simple_entry
+        refute @response.headers['X-Content-Digest'].nil?
+        @entity_store.purge(@response.headers['X-Content-Digest'])
+        def @store.purge(key); raise NotImplementedError; end
+        @store.lookup(@request, @entity_store).must_be_nil
+        @store.lookup(@request, @entity_store).must_be_nil
+      end
+
       it 'restores response headers properly with #lookup' do
         store_simple_entry
         response = @store.lookup(@request, @entity_store)


### PR DESCRIPTION
Resolves issue https://github.com/rtomayko/rack-cache/issues/155 by warning once per class if purge isn't implemented.

A few notes:

1. I could not figure out a satisfactory way to truly warn on initialization in a backward compatible manner.

  - The purge method itself has thrown `NotImplementedError` for a long time. It's really just the lookup method that needs resolution.
  - There is no way to know at load time what implementation/configuration is actually going to be used. The only real way to do understand is catch the `NotImplementedError` in the `lookup`. Anything more seems to imply some other architectural changes that would require more than a patch level version update so I went with this for now.

2. I went with a simple `warn` call since that seems to be used elsewhere in the code.

3. I'm not very familiar with MiniTest and googling around I wasn't able to figure out how to effectively ensure that `warn` was called exactly once per class. I left it at calling the method 2x and visually checking the warning only prints once. This makes me feel kinda icky though. I'm open to suggestions.

4. The warn_once is not technically thread safe in the sense that there is a race condition where multiple threads could print a warning message if they check the key at the same time. I figured on occasional double warning is ok in this case rather than the overhead of dealing with a mutex.

5. I went with the simple `warn_once(key)` and building the message in a block rather than passing it to the method for performance reasons. Normally I'd consider this premature optimization, but since this is a performance boosting gem I thought paying attention here would be good. Let me know if you want to switch to just using `warn_once(message)`.