### PR TITLE
Pass Options To Underlying Storage Driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ cache: bundler
 branches:
   only: master
 rvm:
-  - 2.0
-  - 2.1
-  - 2.2
   - 2.3
   - 2.4
   - 2.5

--- a/lib/rack/cache/context.rb
+++ b/lib/rack/cache/context.rb
@@ -19,6 +19,7 @@ module Rack::Cache
       @backend = backend
       @trace = []
       @env = nil
+      @options = options
 
       initialize_options options
       yield self if block_given?
@@ -31,14 +32,14 @@ module Rack::Cache
     # value effects the result of this method immediately.
     def metastore
       uri = options['rack-cache.metastore']
-      storage.resolve_metastore_uri(uri)
+      storage.resolve_metastore_uri(uri, @options)
     end
 
     # The configured EntityStore instance. Changing the rack-cache.entitystore
     # value effects the result of this method immediately.
     def entitystore
       uri = options['rack-cache.entitystore']
-      storage.resolve_entitystore_uri(uri)
+      storage.resolve_entitystore_uri(uri, @options)
     end
 
     # The Rack call interface. The receiver acts as a prototype and runs

--- a/lib/rack/cache/entity_store.rb
+++ b/lib/rack/cache/entity_store.rb
@@ -33,10 +33,10 @@ module Rack::Cache
 
     # Stores entity bodies on the heap using a Hash object.
     class Heap < EntityStore
-
       # Create the store with the specified backing Hash.
-      def initialize(hash={})
+      def initialize(hash={}, options = {})
         @hash = hash
+        @options = options
       end
 
       # Determine whether the response body with the specified key (SHA1)
@@ -71,8 +71,8 @@ module Rack::Cache
         nil
       end
 
-      def self.resolve(uri)
-        new
+      def self.resolve(uri, options = {})
+        new({}, options)
       end
     end
 

--- a/lib/rack/cache/meta_store.rb
+++ b/lib/rack/cache/meta_store.rb
@@ -198,8 +198,9 @@ module Rack::Cache
     # Concrete MetaStore implementation that uses a simple Hash to store
     # request/response pairs on the heap.
     class Heap < MetaStore
-      def initialize(hash={})
+      def initialize(hash={}, options = {})
         @hash = hash
+        @options = options
       end
 
       def read(key)
@@ -223,8 +224,8 @@ module Rack::Cache
         @hash
       end
 
-      def self.resolve(uri)
-        new
+      def self.resolve(uri, options = {})
+        new({}, options)
       end
     end
 

--- a/lib/rack/cache/storage.rb
+++ b/lib/rack/cache/storage.rb
@@ -14,12 +14,12 @@ module Rack::Cache
       @entitystores = {}
     end
 
-    def resolve_metastore_uri(uri)
-      @metastores[uri.to_s] ||= create_store(MetaStore, uri)
+    def resolve_metastore_uri(uri, options = {})
+      @metastores[uri.to_s] ||= create_store(MetaStore, uri, options)
     end
 
-    def resolve_entitystore_uri(uri)
-      @entitystores[uri.to_s] ||= create_store(EntityStore, uri)
+    def resolve_entitystore_uri(uri, options = {})
+      @entitystores[uri.to_s] ||= create_store(EntityStore, uri, options)
     end
 
     def clear
@@ -30,12 +30,13 @@ module Rack::Cache
 
   private
 
-    def create_store(type, uri)
+    def create_store(type, uri, options = {})
       if uri.respond_to?(:scheme) || uri.respond_to?(:to_str)
         uri = URI.parse(uri) unless uri.respond_to?(:scheme)
         if type.const_defined?(uri.scheme.upcase)
           klass = type.const_get(uri.scheme.upcase)
-          klass.resolve(uri)
+          return klass.resolve(uri) if klass.method(:resolve).arity == 1
+          klass.resolve(uri, options)
         else
           fail "Unknown storage provider: #{uri.to_s}"
         end

--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -5,6 +5,16 @@ describe Rack::Cache::Context do
   before { setup_cache_context }
   after  { teardown_cache_context }
 
+  it 'passes options to the underlying stores' do
+    app = CacheContextHelpers::FakeApp.new(200, {}, ['foo'])
+    context = Rack::Cache::Context.new(app, foo: 'bar')
+    entity_options = context.entitystore.instance_variable_get('@options')
+    meta_options = context.metastore.instance_variable_get('@options')
+
+    entity_options[:foo].must_equal('bar')
+    meta_options[:foo].must_equal('bar')
+  end
+
   it 'passes on non-GET/HEAD requests' do
     respond_with 200
     post '/'

--- a/test/storage_test.rb
+++ b/test/storage_test.rb
@@ -10,6 +10,17 @@ describe Rack::Cache::Storage do
     lambda { @storage.resolve_metastore_uri('foo:/') }.must_raise
   end
 
+  it "passes options to the underlying stores" do
+    @storage
+      .resolve_metastore_uri('heap:/', foo: 'bar')
+      .instance_variable_get('@options')[:foo]
+      .must_equal('bar')
+    @storage
+      .resolve_entitystore_uri('heap:/', foo: 'bar')
+      .instance_variable_get('@options')[:foo]
+      .must_equal('bar')
+  end
+
   it "creates a new MetaStore for URI if none exists" do
     @storage.resolve_metastore_uri('heap:/').
       must_be_kind_of Rack::Cache::MetaStore

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,7 @@ require 'stringio'
 
 [STDOUT, STDERR].each { |io| io.sync = true }
 
+require 'maxitest/global_must'
 require 'maxitest/autorun'
 require 'mocha/setup'
 


### PR DESCRIPTION
While implementing compression for `Redis::Rack::Cache` in
redis-store/redis-rack-cache#30, I noticed that it's not possible to
pass options down to the underlying store, resulting in a
less-than-ideal solution for users of the gem to configure whether they
want responses to be sent over the wire compressed to Redis and
decompressed on the way back. To resolve this, I propose that any
additional options not being used by `Rack::Cache` should be passed into
the underlying storage driver as a hash of options, although this is
backwards-compatible for drivers that don't need any additional options.

It would really help us out a lot if we had something like this in
`Rack::Cache` so custom options that only pertain to the underlying
store (such as connection pool or Redis cluster options) can be passed
in the same Hash as everything else in rack-cache.