### PR TITLE
Add a proc to allow ignoring parts of the query string in the key

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Does not persist response bodies (no disk/memory used).<br/>
 Responses from the cache will have an empty body.<br/>
 Clients must ignore these empty cached response (check for X-Rack-Cache response header).<br/>
 Atm cannot handle streamed responses, patch needed.
- 
+
 ```Ruby
 require 'rack/cache'
 
@@ -109,6 +109,18 @@ use Rack::Cache,
 run app
 ```
 
+Ignoring tracking parameters in cache keys
+-----------------
+
+It's fairly common to include tracking parameters which don't affect the content
+of the page. Since Rack::Cache uses the full URL as part of the cache key, this
+can cause unneeded churn in your cache. If you're using the default key class
+`Rack::Cache::Key`, you can configure a proc to ignore certain keys/values like
+so:
+
+```Ruby
+Rack::Cache::Key.query_string_ignore = proc { |k, v| k =~ /^(trk|utm)_/ }
+```
+
 License: MIT<br/>
 [![Build Status](https://travis-ci.org/rtomayko/rack-cache.svg)](https://travis-ci.org/rtomayko/rack-cache)
-

--- a/doc/configuration.markdown
+++ b/doc/configuration.markdown
@@ -116,13 +116,19 @@ the appropriate cache key.
 
 The `Rack::Cache::Key` class by default returns the fully qualified url of the request.
 
-In addition to setting the generator to an object, you can just pass a block instead, 
+If you're using `Rack::Cache::Key` and would like to omit parts of the query string
+from the key (e.g. tracking with UTM parameters), you can set a `Proc` on
+`Rack::Cache::Key` like so:
+
+  Rack::Cache::Key.query_string_ignore = proc { |k, v| k =~ /^(trk|utm)_/ }
+
+In addition to setting the generator to an object, you can just pass a block instead,
 which will act as the cache key generator:
-	
+
 	set :cache_key do |request|
 		request.fullpath.replace(/\//, '-')
 	end
-	
+
 For more options see the [Rack::Request documentation](http://rack.rubyforge.org/doc/classes/Rack/Request.html)
 
 ### `use_native_ttl`
@@ -134,4 +140,3 @@ policy.
 
 If using `memcached`, it will speed up misses slightly as the middleware won't
 need to fetch metadata and check timestamps.
-

--- a/test/key_test.rb
+++ b/test/key_test.rb
@@ -60,4 +60,17 @@ describe Rack::Cache::Key do
     request = mock_request('/test?x=y', "HTTP_HOST" => 'www2.example.org')
     new_key(request).must_equal "http://www2.example.org/test?x=y"
   end
+
+  it "ignores params based on configuration" do
+    begin
+      Rack::Cache::Key.query_string_ignore = proc { |k, v| k == 'a' }
+
+      request = mock_request('/test?a=first&z=last')
+      new_key(request).wont_include('a=first')
+      new_key(request).must_include('z=last')
+
+    ensure
+      Rack::Cache::Key.query_string_ignore = nil
+    end
+  end
 end


### PR DESCRIPTION
A proc for ignoring parts of query strings when generating a key. This is useful when you have parameters like `utm` or `trk` that don't affect the content on the page and are unique per-visitor or campaign. Parameters like these will be part of the key and cause a lot of churn.

Thought I'd open this as a PR to see if the maintainers were interested. Lemme know if otherwise, and I'll just monkey patch in my project!