### PR TITLE
remove query in key when all params are ignored

### DIFF
--- a/lib/rack/cache/key.rb
+++ b/lib/rack/cache/key.rb
@@ -62,7 +62,7 @@ module Rack::Cache
       parts.sort!
       parts.reject!(&self.class.query_string_ignore)
       parts.map! { |k,v| "#{escape(k)}=#{escape(v)}" }
-      parts.join('&')
+      parts.empty? ? nil : parts.join('&')
     end
   end
 end

--- a/test/key_test.rb
+++ b/test/key_test.rb
@@ -73,4 +73,15 @@ describe Rack::Cache::Key do
       Rack::Cache::Key.query_string_ignore = nil
     end
   end
+
+  it "does not include query when all params are ignored" do
+    begin
+      Rack::Cache::Key.query_string_ignore = proc { |k, v| k == 'a' }
+
+      request = mock_request('/test?a=a')
+      new_key(request).wont_include('?')
+    ensure
+      Rack::Cache::Key.query_string_ignore = nil
+    end
+  end
 end


### PR DESCRIPTION
Currently when all Params are ignored with the proc given in Rack::Cache::Key.query_string_ignore, the resulting Cache-Key still contains the "?". This means, that the page cannot use the same cache as when using the same path without params.