### PR TITLE
Add a fault_tolerant flag to fail-over to stale cache

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+## 1.12.0
+
+ * Add a fault_tolerant flag to fail-over to stale cache
+
 ## 1.11.1
 
  * when ignoring parts of the query, remove query in key when all params are ignored

--- a/doc/configuration.markdown
+++ b/doc/configuration.markdown
@@ -140,3 +140,9 @@ policy.
 
 If using `memcached`, it will speed up misses slightly as the middleware won't
 need to fetch metadata and check timestamps.
+
+### `fault_tolerant`
+
+Boolean specifying whether fault tolerant caching is enabled. When this option
+is enabled (`rack-cache.fault_tolerant`is `true`), stale cached results can be
+returned if the downstream service is unavailable.

--- a/lib/rack/cache/options.rb
+++ b/lib/rack/cache/options.rb
@@ -107,6 +107,10 @@ module Rack::Cache
     # be used.
     option_accessor :use_native_ttl
 
+    # Specifies whether to serve a request from a stale cache entry if
+    # the attempt to revalidate the cache entry raises an exception.
+    option_accessor :fault_tolerant
+
     # The underlying options Hash. During initialization (or outside of a
     # request), this is a default values Hash. During a request, this is the
     # Rack environment Hash. The default values Hash is merged in underneath
@@ -149,6 +153,7 @@ module Rack::Cache
         'rack-cache.allow_reload'     => false,
         'rack-cache.allow_revalidate' => false,
         'rack-cache.use_native_ttl'   => false,
+        'rack-cache.fault_tolerant'   => false,
       }
       self.options = options
     end

--- a/rack-cache.gemspec
+++ b/rack-cache.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new 'rack-cache', '1.11.1' do |s|
+Gem::Specification.new 'rack-cache', '1.12.0' do |s|
   s.summary     = "HTTP Caching for Rack"
   s.description = "Rack::Cache is suitable as a quick drop-in component to enable HTTP caching for Rack-based applications that produce freshness (Expires, Cache-Control) and/or validation (Last-Modified, ETag) information."
   s.required_ruby_version = '>= 2.3.0'


### PR DESCRIPTION
Redoing #91 

> Rack::Cache includes an option to enable fault tolerant caching, so that stale cached results can be returned if the downstream service is unavailable. Just set :fault_tolerant => true in the options hash.

@grosser I agree that `fault_tolerant` can mean many things but can we keep this name? I tried to reflect other points in [your comment](https://github.com/rtomayko/rack-cache/pull/91#issuecomment-637916726).

@jfeltesse-mdsol @jcarres-mdsol 