### PR TITLE
Fix case sensitivity of the Vary and Age headers

### DIFF
--- a/lib/rack/cache/meta_store.rb
+++ b/lib/rack/cache/meta_store.rb
@@ -34,7 +34,7 @@ module Rack::Cache
 
       # find a cached entry that matches the request.
       env = request.env
-      match = entries.detect{|req,res| requests_match?(res['Vary'], env, req)}
+      match = entries.detect{ |req,res| requests_match?(vary(res), env, req) }
       return nil if match.nil?
 
       _, res = match
@@ -90,13 +90,13 @@ module Rack::Cache
       # the list
       vary = response.vary
       entries =
-        read(key).reject do |env,res|
-          (vary == res['Vary']) &&
+        read(key).reject do |env, res|
+          (vary == vary(res)) &&
             requests_match?(vary, env, stored_env)
         end
 
       headers = persist_response(response)
-      headers.delete 'Age'
+      headers.delete(hash_key(headers, 'Age'))
 
       entries.unshift [stored_env, headers]
       if request.env['rack-cache.use_native_ttl'] && response.fresh?
@@ -163,6 +163,17 @@ module Rack::Cache
         key = "HTTP_#{header.upcase.tr('-', '_')}"
         env1[key] == env2[key]
       end
+    end
+
+    # Retrieve the literal value of the Vary header from a cached response hash
+    # without case sensitivity.
+    def vary(hash)
+      hash[hash_key(hash, 'Vary')]
+    end
+
+    def hash_key(hash, key)
+      hash.each_key { |k| return k if k.casecmp(key).zero? }
+      nil
     end
 
   protected

--- a/test/meta_store_test.rb
+++ b/test/meta_store_test.rb
@@ -249,52 +249,64 @@ module RackCacheMetaStoreImplementation
 
       # Vary =======================================================================
 
-      it 'does not return entries that Vary with #lookup' do
-        req1 = mock_request('/test', {'HTTP_FOO' => 'Foo', 'HTTP_BAR' => 'Bar'})
-        req2 = mock_request('/test', {'HTTP_FOO' => 'Bling', 'HTTP_BAR' => 'Bam'})
-        res = mock_response(200, {'Vary' => 'Foo Bar'}, ['test'])
-        @store.store(req1, res, @entity_store)
+      %w[Vary vary VARY vArY].each do |vary|
+        it 'does not return entries that Vary with #lookup' do
+          req1 = mock_request('/test', {'HTTP_FOO' => 'Foo', 'HTTP_BAR' => 'Bar'})
+          req2 = mock_request('/test', {'HTTP_FOO' => 'Bling', 'HTTP_BAR' => 'Bam'})
+          res = mock_response(200, {vary => 'Foo Bar'}, ['test'])
+          @store.store(req1, res, @entity_store)
 
-        @store.lookup(req2, @entity_store).must_be_nil
+          @store.lookup(req2, @entity_store).must_be_nil
+        end
+
+        it 'stores multiple responses for each Vary combination' do
+          req1 = mock_request('/test', {'HTTP_FOO' => 'Foo',   'HTTP_BAR' => 'Bar'})
+          res1 = mock_response(200, {vary => 'Foo Bar'}, ['test 1'])
+          key = @store.store(req1, res1, @entity_store)
+
+          req2 = mock_request('/test', {'HTTP_FOO' => 'Bling', 'HTTP_BAR' => 'Bam'})
+          res2 = mock_response(200, {vary => 'Foo Bar'}, ['test 2'])
+          @store.store(req2, res2, @entity_store)
+
+          req3 = mock_request('/test', {'HTTP_FOO' => 'Baz',   'HTTP_BAR' => 'Boom'})
+          res3 = mock_response(200, {vary => 'Foo Bar'}, ['test 3'])
+          @store.store(req3, res3, @entity_store)
+
+          slurp(@store.lookup(req3, @entity_store).body).must_equal 'test 3'
+          slurp(@store.lookup(req1, @entity_store).body).must_equal 'test 1'
+          slurp(@store.lookup(req2, @entity_store).body).must_equal 'test 2'
+
+          @store.read(key).length.must_equal 3
+        end
+
+        it 'overwrites non-varying responses with #store' do
+          req1 = mock_request('/test', {'HTTP_FOO' => 'Foo',   'HTTP_BAR' => 'Bar'})
+          res1 = mock_response(200, {vary => 'Foo Bar'}, ['test 1'])
+          key = @store.store(req1, res1, @entity_store)
+          slurp(@store.lookup(req1, @entity_store).body).must_equal 'test 1'
+
+          req2 = mock_request('/test', {'HTTP_FOO' => 'Bling', 'HTTP_BAR' => 'Bam'})
+          res2 = mock_response(200, {vary => 'Foo Bar'}, ['test 2'])
+          @store.store(req2, res2, @entity_store)
+          slurp(@store.lookup(req2, @entity_store).body).must_equal 'test 2'
+
+          req3 = mock_request('/test', {'HTTP_FOO' => 'Foo',   'HTTP_BAR' => 'Bar'})
+          res3 = mock_response(200, {vary => 'Foo Bar'}, ['test 3'])
+          @store.store(req3, res3, @entity_store)
+          slurp(@store.lookup(req1, @entity_store).body).must_equal 'test 3'
+
+          @store.read(key).length.must_equal 2
+        end
       end
 
-      it 'stores multiple responses for each Vary combination' do
-        req1 = mock_request('/test', {'HTTP_FOO' => 'Foo',   'HTTP_BAR' => 'Bar'})
-        res1 = mock_response(200, {'Vary' => 'Foo Bar'}, ['test 1'])
-        key = @store.store(req1, res1, @entity_store)
+      # Age ====================================================================
 
-        req2 = mock_request('/test', {'HTTP_FOO' => 'Bling', 'HTTP_BAR' => 'Bam'})
-        res2 = mock_response(200, {'Vary' => 'Foo Bar'}, ['test 2'])
-        @store.store(req2, res2, @entity_store)
-
-        req3 = mock_request('/test', {'HTTP_FOO' => 'Baz',   'HTTP_BAR' => 'Boom'})
-        res3 = mock_response(200, {'Vary' => 'Foo Bar'}, ['test 3'])
-        @store.store(req3, res3, @entity_store)
-
-        slurp(@store.lookup(req3, @entity_store).body).must_equal 'test 3'
-        slurp(@store.lookup(req1, @entity_store).body).must_equal 'test 1'
-        slurp(@store.lookup(req2, @entity_store).body).must_equal 'test 2'
-
-        @store.read(key).length.must_equal 3
-      end
-
-      it 'overwrites non-varying responses with #store' do
-        req1 = mock_request('/test', {'HTTP_FOO' => 'Foo',   'HTTP_BAR' => 'Bar'})
-        res1 = mock_response(200, {'Vary' => 'Foo Bar'}, ['test 1'])
-        key = @store.store(req1, res1, @entity_store)
-        slurp(@store.lookup(req1, @entity_store).body).must_equal 'test 1'
-
-        req2 = mock_request('/test', {'HTTP_FOO' => 'Bling', 'HTTP_BAR' => 'Bam'})
-        res2 = mock_response(200, {'Vary' => 'Foo Bar'}, ['test 2'])
-        @store.store(req2, res2, @entity_store)
-        slurp(@store.lookup(req2, @entity_store).body).must_equal 'test 2'
-
-        req3 = mock_request('/test', {'HTTP_FOO' => 'Foo',   'HTTP_BAR' => 'Bar'})
-        res3 = mock_response(200, {'Vary' => 'Foo Bar'}, ['test 3'])
-        @store.store(req3, res3, @entity_store)
-        slurp(@store.lookup(req1, @entity_store).body).must_equal 'test 3'
-
-        @store.read(key).length.must_equal 2
+      %w[Age age AGE AgE].each do |age|
+        it 'removes the Age response header before storing' do
+          response = mock_response(200, {age => "100"}, ['foo'])
+          @store.store(@request, response, @entity_store)
+          @store.lookup(@request, @entity_store).headers['Age'].must_be_nil
+        end
       end
 
       # TTL ====================================================================

--- a/test/meta_store_test.rb
+++ b/test/meta_store_test.rb
@@ -249,7 +249,7 @@ module RackCacheMetaStoreImplementation
 
       # Vary =======================================================================
 
-      %w[Vary vary VARY vArY].each do |vary|
+      %w[Vary vary].each do |vary|
         it 'does not return entries that Vary with #lookup' do
           req1 = mock_request('/test', {'HTTP_FOO' => 'Foo', 'HTTP_BAR' => 'Bar'})
           req2 = mock_request('/test', {'HTTP_FOO' => 'Bling', 'HTTP_BAR' => 'Bam'})
@@ -301,7 +301,7 @@ module RackCacheMetaStoreImplementation
 
       # Age ====================================================================
 
-      %w[Age age AGE AgE].each do |age|
+      %w[Age age].each do |age|
         it 'removes the Age response header before storing' do
           response = mock_response(200, {age => "100"}, ['foo'])
           @store.store(@request, response, @entity_store)


### PR DESCRIPTION
### Background

When we started receiving responses with a lowercased `vary` header, we observed cache miss and resulting in bloated cache entries.

### Details

When looking up the Vary header in a response, the headers are [looked up](https://github.com/rtomayko/rack-cache/blob/d4821f7c6063586a1e1ba7f706c107ce30a15d81/lib/rack/cache/response.rb#L251-L253) in a [case-insensitive hash implementation](https://github.com/rack/rack/blob/d15dd728440710cfc35ed155d66a98dc2c07ae42/lib/rack/utils.rb#L421-L425). 
However, when [persisting](https://github.com/rtomayko/rack-cache/blob/d4821f7c6063586a1e1ba7f706c107ce30a15d81/lib/rack/cache/meta_store.rb#L153), the headers are stored into a [normal (case-sensitive) hash](https://github.com/rack/rack/blob/d15dd728440710cfc35ed155d66a98dc2c07ae42/lib/rack/utils.rb#L458-L462).

The current Vary header value is compared to a cached value retrieved from a case-sensitive hash, resulting in not matching and adding another response to the meta entry:

(`res` is a case-sensitive hash)
https://github.com/rtomayko/rack-cache/blob/d4821f7c6063586a1e1ba7f706c107ce30a15d81/lib/rack/cache/meta_store.rb#L37
https://github.com/rtomayko/rack-cache/blob/d4821f7c6063586a1e1ba7f706c107ce30a15d81/lib/rack/cache/meta_store.rb#L92-L94

### Changes summary
- Retrieve the `Vary` header value from a cached response hash without case sensitivity
- Also, delete the `Age` header without case sensitivity